### PR TITLE
Added .editorconfig with settings that reflect the project as it appears now

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+
+# Change these settings to your own preference
+indent_style = space
+indent_size = 4
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[{package.json,.travis.yml}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
The concept behind [editorconfig](http://editorconfig.org/) is fairly simple, ensure you are using the same settings across multiple IDEs. My personall default settings at 2 space tabs, but that is not the case with this project. Trying to work with the code can get frustrating when you are constantly fighting your IDE of choice for formatting. This will help ensure that a consistent coding style is used within this project.
