### PR TITLE
Fix middleware request resource path

### DIFF
--- a/libs/fetcher.js
+++ b/libs/fetcher.js
@@ -77,7 +77,7 @@ var OP_READ = 'read',
             var request;
 
             if (req.method === GET) {
-                var path = req.path.substr('/resource/'.length).split(';');
+                var path = req.path.substr(req.path.lastIndexOf('/resource/') + '/resource/'.length).split(';');
                 request = {
                     req: req,
                     resource: path.shift(),


### PR DESCRIPTION
Don't assume req.path starts with /resource/.
