### PR TITLE
emulating old behavior, non success http statuses return an error

### DIFF
--- a/libs/util/http.client.js
+++ b/libs/util/http.client.js
@@ -179,13 +179,25 @@ function io(url, options) {
         timeout: options.timeout,
         headers: options.headers,
         body: options.data
-    }, function (err, r, body) {
-        if (err) {
-            options.on.failure.call(r.rawRequest, err, body);
-        } else {
-            options.on.success.call(r.rawRequest, null, body);
+    }, function (err, resp, body) {
+        var status = resp.statusCode;
+        var errMessage;
+
+        if (!err && (status === 0 || (status >= 400 && status < 600))) {
+            if (typeof body === 'string') {
+                errMessage = body;
+            } else {
+                errMessage = status ? 'Error ' + status : 'Internal XMLHttpRequest Error';
+            }
+
+            err = new Error(errMessage);
         }
 
+        if (err) {
+            options.on.failure.call(resp.rawRequest, err, body);
+        } else {
+            options.on.success.call(resp.rawRequest, null, body);
+        }
     });
 }
 


### PR DESCRIPTION
Resolves #46 

FYI: the `xhr` 2.0 PR didn't end up keeping the `options.httpErrors` setting which would've thrown an error with non successful http requests. [Here is the commit](https://github.com/Raynos/xhr/commit/5714cde39f9d48e4bd669bb76812782a1e213b84#diff-168726dbe96b3ce427e7fedce31bb0bcL150) that removed that option from the original PR.

We adopted the logic they were using internally in our `libs/util/http.client.js:io` function.
