### PR TITLE
Allow JSON thru on error

### DIFF
--- a/libs/util/http.client.js
+++ b/libs/util/http.client.js
@@ -175,7 +175,11 @@ function io(url, options) {
                 errMessage = status ? 'Error ' + status : 'Internal XMLHttpRequest Error';
             }
 
-            err = new Error(errMessage);
+            try {
+                err = JSON.parse(errMessage);
+            } catch (e) {
+                err = new Error(errMessage);
+            }
             err.statusCode = status;
             if (408 === status || 0 === status) {
                 err.timeout = options.timeout;


### PR DESCRIPTION
@mridgway @lingyan @redonkulus 

This change allows JSON from error responses to be passed back to our app but I am not certain if there is a better way of achieving this. We are receiving error codes and messages from APIs that we would like to run through i18n and display to our users.  

We could possibly pass statusCode and a new property called `jsonMessage` from the context.service callback which Fetchr might handle differently? 
```
callback({
    statusCode: err.statusCode,
    jsonMessage: err
}, res);
```

