### PR TITLE
Pass response body for errors

### DIFF
--- a/libs/util/http.client.js
+++ b/libs/util/http.client.js
@@ -177,6 +177,7 @@ function io(url, options) {
 
             err = new Error(errMessage);
             err.statusCode = status;
+            err.body = body;
             if (408 === status || 0 === status) {
                 err.timeout = options.timeout;
             }


### PR DESCRIPTION
We do not pass response in the event of errors but often APIs provide lots of good details in an error response, such as error codes that we can use to notify the user about. This change attaches body of api response to the err object.  