### PR TITLE
Add fallback config object

### DIFF
--- a/libs/fetcher.js
+++ b/libs/fetcher.js
@@ -130,7 +130,7 @@ function parseParamValues (params) {
                     operation: singleRequest.operation,
                     params: singleRequest.params,
                     body: singleRequest.body || {},
-                    config: singleRequest.config,
+                    config: {},
                     callback: function(err, data, meta) {
                         meta = meta || {};
                         if (meta.headers) {


### PR DESCRIPTION
For requests other than "GET" requests, add a fallback config object so config is never undefined when service is called.

Is response to: #94 