### PR TITLE
handle error 400 json responses and standard string responses

### DIFF
--- a/libs/util/http.client.js
+++ b/libs/util/http.client.js
@@ -168,18 +168,27 @@ function io(url, options) {
         useXDR: options.cors
     }, function (err, resp, body) {
         var status = resp.statusCode;
-        var errMessage;
+        var errMessage, errBody;
 
         if (!err && (status === 0 || (status >= 400 && status < 600))) {
             if (typeof body === 'string') {
-                errMessage = body;
+                try {
+                    errBody = JSON.parse(body);
+                    if (errBody.message) {
+                        errMessage = errBody.message;
+                    } else {
+                        errMessage = body;
+                    }
+                } catch(e) {
+                    errMessage = body;
+                }
             } else {
                 errMessage = status ? 'Error ' + status : 'Internal Fetchr XMLHttpRequest Error';
             }
 
             err = new Error(errMessage);
             err.statusCode = status;
-            err.body = body;
+            err.body = errBody || body;
             if (408 === status || 0 === status) {
                 err.timeout = options.timeout;
             }


### PR DESCRIPTION
This should hopefully fix #90. I've tried to incorporate appropriate tests based on scenarios that I've seen before the commit created the problem, as well as scenarios I saw from an IIS server housing node where it stripped out the body content.