### PR TITLE
Remove X-Requested-With header when performing CORS requests

### DIFF
--- a/libs/util/http.client.js
+++ b/libs/util/http.client.js
@@ -43,10 +43,11 @@ if (!String.prototype.trim) {
   };
 }
 
-function normalizeHeaders(headers, method) {
-    var normalized = {
-        'X-Requested-With': 'XMLHttpRequest'
-    };
+function normalizeHeaders(headers, method, isCors) {
+    var normalized = {};
+    if (!isCors) {
+        normalized['X-Requested-With'] = 'XMLHttpRequest';
+    }
     var needContentType = (method === METHOD_PUT || method === METHOD_POST);
     _.forEach(headers, function (v, field) {
         if (field.toLowerCase() === 'content-type') {
@@ -130,8 +131,8 @@ function mergeConfig(config) {
 function doXhr(method, url, headers, data, config, callback) {
     var options, timeout;
 
+    headers = normalizeHeaders(headers, method, config.cors);
     config = mergeConfig(config);
-    headers = normalizeHeaders(headers, method);
     // use config.tmp to store temporary values
     config.tmp = config.tmp || {retry_counter: 0};
 

--- a/tests/unit/libs/util/http.client.js
+++ b/tests/unit/libs/util/http.client.js
@@ -101,6 +101,69 @@ describe('Client HTTP', function () {
         });
     });
 
+    describe('#Successful CORS requests', function () {
+        beforeEach(function () {
+            mockResponse = {
+                statusCode: 200
+            };
+            mockBody = 'BODY';
+            xhrOptions = [];
+        });
+
+        it('GET', function (done) {
+            http.get('/url', {'X-Foo': 'foo'}, {cors: true}, function (err, response) {
+                expect(xhrOptions.length).to.equal(1);
+                var options = xhrOptions[0];
+                expect(options.url).to.equal('/url');
+                expect(options.headers).to.not.have.property('X-Requested-With');
+                expect(options.headers['X-Foo']).to.equal('foo');
+                expect(options.method).to.equal('GET');
+                expect(err).to.equal(null);
+                expect(response.statusCode).to.equal(200);
+                expect(response.responseText).to.equal('BODY');
+                done();
+            });
+        });
+
+        it('PUT', function (done) {
+            http.put('/url', {'X-Foo': 'foo'}, {data: 'data'}, {cors: true}, function () {
+                expect(xhrOptions.length).to.equal(1);
+                var options = xhrOptions[0];
+                expect(options.url).to.equal('/url');
+                expect(options.headers).to.not.have.property('X-Requested-With');
+                expect(options.headers['X-Foo']).to.equal('foo');
+                expect(options.method).to.equal('PUT');
+                expect(options.body).to.eql('{"data":"data"}');
+                done();
+            });
+        });
+
+        it('POST', function (done) {
+            http.post('/url', {'X-Foo': 'foo'}, {data: 'data'}, {cors: true}, function () {
+                expect(xhrOptions.length).to.equal(1);
+                var options = xhrOptions[0];
+                expect(options.url).to.equal('/url');
+                expect(options.headers).to.not.have.property('X-Requested-With');
+                expect(options.headers['X-Foo']).to.equal('foo');
+                expect(options.method).to.equal('POST');
+                expect(options.body).to.eql('{"data":"data"}');
+                done();
+            });
+        });
+
+        it('DELETE', function (done) {
+            http['delete']('/url', {'X-Foo': 'foo'}, {cors: true}, function () {
+                expect(xhrOptions.length).to.equal(1);
+                var options = xhrOptions[0];
+                expect(options.url).to.equal('/url');
+                expect(options.headers).to.not.have.property('X-Requested-With');
+                expect(options.headers['X-Foo']).to.equal('foo');
+                expect(options.method).to.equal('DELETE');
+                done();
+            });
+        });
+    });
+
     describe('#400 requests', function () {
         beforeEach(function () {
             xhrOptions = [];


### PR DESCRIPTION
This PR prevents the `X-Requested-With` header from being set when making CORS requests, since that header causes an undesired preflight OPTIONS request. See #83 for original mention.