### PR TITLE
add context picker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,39 @@ fetcher
 
 For requests from the server, the config object is simply passed into the service being called.
 
+## Context Variables
+
+By Default, fetchr appends all context values to the xhr url as query params. `contextPicker` allows you to greater control over which context variables get sent as query params depending on the xhr method (`GET` or `POST`). This is useful when you want to limit the number of variables in a `GET` url in order not to accidentally [cache bust](http://webassets.readthedocs.org/en/latest/expiring.html).
+
+`contextPicker` follows the same format as the `predicate` parameter in [`lodash/object/pick`](https://lodash.com/docs#pick) with three arguments: `(value, key, object)`.
+
+var fetcher = new Fetcher({
+    context: { // These context values are persisted with XHR calls as query params
+        _csrf: 'Ax89D94j',
+        device: 'desktop'
+    },
+    contextPicker: {
+        GET: function (value, key, object) {
+            // for example, if you don't enable CSRF protection for GET, you are able to ignore it with the url
+            if (key === '_csrf') {
+                return false;
+            }
+            rerurn true;
+        }
+        // for other method e.g., POST, if you don't define the picker, it will pick the entire context object
+    }
+});
+
+var fetcher = new Fetcher({
+    context: { // These context values are persisted with XHR calls as query params
+        _csrf: 'Ax89D94j',
+        device: 'desktop'
+    },
+    contextPicker: {
+        GET: ['device'] // predicate can be an array of strings
+    }
+});
+
 ## API
 
 - [Fetchr](https://github.com/yahoo/fetchr/blob/master/docs/fetchr.md)

--- a/docs/fetchr.md
+++ b/docs/fetchr.md
@@ -5,8 +5,14 @@
 Creates a new fetchr plugin instance with the following parameters:
 
  * `options`: An object containing the plugin settings
- * `options.req` (required): The request object.  It can contain per-request/context data.
+ * `options.req` (required on server): The request object.  It can contain per-request/context data.
  * `options.xhrPath` (optional): The path for XHR requests. Will be ignored serverside.
+ * `options.xhrTimeout` (optional): Timeout in milliseconds for all XHR requests
+ * `options.corsPath` (optional): Base CORS path in case CORS is enabled
+ * `options.context` (optional): The context object 
+ * `options.contextPicker` (optional): The context predicate functions, it will be applied to lodash/object/pick to pick values from context object
+ * `options.contextPicker.GET` (optional): GET predicate function
+ * `options.contextPicker.POST` (optional): POST predicate function
 
 ## Static Methods
 

--- a/tests/unit/libs/fetcher.client.js
+++ b/tests/unit/libs/fetcher.client.js
@@ -345,6 +345,49 @@ describe('Client Fetcher', function () {
         });
     });
 
+    describe('Context Picker', function () {
+        var context = {_csrf: 'stuff', random: 'randomnumber'};
+        var params = {};
+        var body = {};
+        var config = {};
+        var callback = function(operation, done) {
+                return function(err, data) {
+                    if (err){
+                        done(err);
+                    }
+                    done();
+                };
+            };
+
+        beforeEach(function(){
+            fetcher = new Fetcher({
+                context: context,
+                contextPicker: {
+                    GET: function getContextPicker(value, key, object) {
+                        if (key === 'random') {
+                            return false
+                        }
+                        return true;
+                    }
+                }
+            });
+            validateHTTP({
+                validateGET: function (url, headers, config) {
+                    expect(url).to.contain(DEFAULT_XHR_PATH + '/' + resource);
+                    expect(url).to.contain('?_csrf=' + context._csrf);
+                    // for GET, ignore 'random'
+                    expect(url).to.not.contain('random=' + context.random);
+                },
+                validatePOST: function (url, headers, body, config) {
+                    expect(url).to.equal(DEFAULT_XHR_PATH + '?_csrf=' + context._csrf + '&random=' + context.random);
+                }
+            });
+        });
+
+        testCrud(it, resource, params, body, config, callback);
+    });
+
+
     describe('Utils', function () {
         it('should able to update options', function () {
             fetcher = new Fetcher({


### PR DESCRIPTION
@Vijar @redonkulus @mridgway @lingyan 

Add a new option `contextPicker`, so that users can define how to pick the context values, for example they can ignore certain key for certain method.

the pick function is exactly the predicate function of `lodash/object/pick`, 

```js
var fetcher = new Fetcher({
    context: { // These context values are persisted with XHR calls as query params
        _csrf: 'Ax89D94j',
        device: 'desktop'
    },
    contextPicker: {
        GET: function (value, key, object) {
            // for example, if you don't enable CSRF protection for GET, you are able to ignore it with the url
            if (key === '_csrf') {
                return false;
            }
            rerurn true;
        }
        // for other method e.g., POST, if you don't define the picker, it will pick the entire context object
    }
});
```