### PR TITLE
chain promise to avoid bluebird's "Unhandled rejection" error

### DIFF
--- a/libs/fetcher.client.js
+++ b/libs/fetcher.client.js
@@ -132,7 +132,7 @@ Request.prototype.end = function (callback) {
         setImmediate(executeRequest, self, resolve, reject);
     });
 
-    promise.then(function (result) {
+    promise = promise.then(function (result) {
         if (result.meta) {
             self.options._serviceMeta.push(result.meta)
         };

--- a/libs/fetcher.js
+++ b/libs/fetcher.js
@@ -137,7 +137,7 @@ Request.prototype.end = function (callback) {
         setImmediate(executeRequest, self, resolve, reject);
     });
 
-    promise.then(function (result) {
+    promise = promise.then(function (result) {
         if (result.meta) {
             self.serviceMeta.push(result.meta)
         };


### PR DESCRIPTION
@Vijar @mridgway 

bluebird prints "Unhandled rejection" error when the promise is rejected without a rejected handler: https://github.com/petkaantonov/bluebird/blob/master/src/captured_trace.js#L267

fetchr.js currently uses `global.Promise`, which could be set by app to bluebird.  So to suppress this bluebird error, we need to register a no-op rejected handler.

Alternative is to simply use es6-promise in fetchr, instead of global.Promise and fallback to es6-promise.