### PR TITLE
Allow setting of headers for erroneous responses

### DIFF
--- a/libs/fetcher.js
+++ b/libs/fetcher.js
@@ -59,7 +59,8 @@ function getErrorResponse(err) {
 
     return {
         statusCode: statusCode,
-        output: output
+        output: output,
+        meta: err.meta
     };
 }
 
@@ -148,6 +149,9 @@ Request.prototype.end = function (callback) {
         promise.then(function (result) {
             setImmediate(callback, null, result.data, result.meta);
         }, function (err) {
+            if (err.meta) {
+                self.serviceMeta.push(err.meta);
+            };
             setImmediate(callback, err);
         });
     } else {

--- a/libs/fetcher.js
+++ b/libs/fetcher.js
@@ -140,12 +140,12 @@ Request.prototype.end = function (callback) {
     promise = promise.then(function (result) {
         if (result.meta) {
             self.serviceMeta.push(result.meta);
-        };
+        }
         return result;
     }, function(errData) {
         if (errData.meta) {
             self.serviceMeta.push(errData.meta);
-        };
+        }
         throw errData.err;
     });
 

--- a/tests/mock/MockErrorService.js
+++ b/tests/mock/MockErrorService.js
@@ -26,7 +26,8 @@ var MockErrorService = {
             output: params.output,
             message: params.message,
             read: 'error'
-        }, null);
+        }, null, this.meta || params.meta);
+        this.meta = null;
     },
     /**
      * create operation (create as in CRUD).
@@ -46,7 +47,8 @@ var MockErrorService = {
             message: params.message,
             output: params.output,
             create: 'error'
-        }, null);
+        }, null, this.meta || params.meta);
+        this.meta = null;
     },
     /**
      * update operation (update as in CRUD).

--- a/tests/unit/libs/fetcher.js
+++ b/tests/unit/libs/fetcher.js
@@ -647,6 +647,27 @@ describe('Server Fetcher', function () {
                         });
                 });
         });
+        it('should have serviceMeta data on error', function (done) {
+            var fetcher = new Fetcher ({
+                req: {}
+            });
+            mockErrorService.meta = {
+                headers: {
+                    'x-foo': 'foo'
+                }
+            };
+            fetcher
+                .read(mockErrorService.name)
+                .params(params)
+                .end(function (err) {
+                    if (err) {
+                        var serviceMeta = fetcher.getServiceMeta();
+                        expect(serviceMeta).to.have.length(1);
+                        expect(serviceMeta[0].headers).to.eql({'x-foo': 'foo'});
+                        done();
+                    }
+                });
+        });
         describe('should work superagent style', function () {
             describe('with callbacks', function () {
                 it('should throw if no resource is given', function () {


### PR DESCRIPTION
Up till version 0.5.17 erroneous responses were able to carry meta-data. Is it possible to reinstate this capability in new versions of fetchr? Or is there a reason for disallowing meta-data from being passed on when the service fails? Thanks!