### PR TITLE
avoid sending undefined params in the uri

### DIFF
--- a/libs/util/defaultConstructGetUri.js
+++ b/libs/util/defaultConstructGetUri.js
@@ -39,7 +39,7 @@ module.exports = function defaultConstructGetUri(baseUri, resource, params, conf
         lodash.forEach(params, function eachParam(v, k) {
             if (k === id_param) {
                 id_val = encodeURIComponent(v);
-            } else {
+            } else if (v !== undefined) {
                 try {
                     matrix.push(k + '=' + encodeURIComponent(jsonifyComplexType(v)));
                 } catch (err) {

--- a/tests/unit/libs/fetcher.client.js
+++ b/tests/unit/libs/fetcher.client.js
@@ -6,6 +6,7 @@
 /*globals before,beforeEach,after,afterEach,describe,it */
 "use strict";
 
+var lodash = require('lodash');
 var libUrl = require('url');
 var expect = require('chai').expect;
 var mockery = require('mockery');
@@ -127,7 +128,8 @@ describe('Client Fetcher', function () {
                     headers: {
                         'x-foo-bar': 'foobar'
                     }
-                }
+                },
+                missing: undefined
             };
         var body = { stuff: 'is'};
         var config = {};
@@ -141,7 +143,7 @@ describe('Client Fetcher', function () {
                     expect(data.operation.success).to.be.true;
                     expect(data.args).to.exist;
                     expect(data.args.resource).to.equal(resource);
-                    expect(data.args.params).to.eql(params);
+                    expect(data.args.params).to.eql(lodash.omit(params, lodash.isUndefined));
                     expect(meta).to.eql(params.meta);
                     done();
                 };
@@ -156,7 +158,7 @@ describe('Client Fetcher', function () {
                     expect(result.data.operation.success).to.be.true;
                     expect(result.data.args).to.exist;
                     expect(result.data.args.resource).to.equal(resource);
-                    expect(result.data.args.params).to.eql(params);
+                    expect(result.data.args.params).to.eql(lodash.omit(params, lodash.isUndefined));
                     expect(result.meta).to.eql(params.meta);
                 } catch (e) {
                     done(e);


### PR DESCRIPTION
fixes #55 

Params that are `undefined` are being passed in the uri and then returned as the string `"undefined"`. It seems more appropriate to avoid sending any params that are `undefined`.