### PR TITLE
Security related fixes

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,6 @@
+*.yml
+.editorconfig
+/docs/
 /artifacts/
 /examples/
 /tests/

--- a/tests/unit/libs/fetcher.js
+++ b/tests/unit/libs/fetcher.js
@@ -552,6 +552,9 @@ describe('Server Fetcher', function () {
             it('should skip invalid GET resource', function (done) {
                 makeInvalidReqTest({method: 'GET', path: '/invalidService'}, 'Bad resource invalidService', done);
             });
+            it('should sanitize resource name for invalid GET resource', function (done) {
+                makeInvalidReqTest({method: 'GET', path: '/invalid&Service'}, 'Bad resource invalid*Service', done);
+            });
             it('should skip invalid POST request', function (done) {
                 makeInvalidReqTest({method: 'POST', body: {
                     requests: {
@@ -560,6 +563,15 @@ describe('Server Fetcher', function () {
                         }
                     }
                 }}, 'Bad resource invalidService', done);
+            });
+            it('should sanitize invalid POST request', function (done) {
+                makeInvalidReqTest({method: 'POST', body: {
+                    requests: {
+                        g0: {
+                            resource: 'invalid&Service'
+                        }
+                    }
+                }}, 'Bad resource invalid*Service', done);
             });
             it('should skip POST request with empty req.body.requests object', function (done) {
                 makeInvalidReqTest({method: 'POST', body: { requests: {}}}, 'No resources', done);


### PR DESCRIPTION
@Vijar @redonkulus 

* escape resource name in error output

Based on [this owasp guideline](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet#RULE_.233.1_-_HTML_escape_JSON_values_in_an_HTML_context_and_read_the_data_with_JSON.parse), 
```
Ensure returned Content-Type header is application/json and not text/html.
This shall instruct the browser not misunderstand the context and execute injected script.
```

Escaping is not needed for JSON data output, as long as the content-type header is set correctly to `Content-Type: application/json; charset=utf-8`, which fetchr already does with `res.json()`.

But there could be legacy browsers with security bugs that do not respect this, such as Opera browser prior to Opera 11.65  (Latest Opera is at 34.0 as of now.): https://www.cvedetails.com/cve/CVE-2012-3557/  

This PR escapes only the message strings fetchr library generates that can be part of the JSON response for addressing legacy browser concerns.  If application is concerned about legacy browser in general, the suggestion is to escape output app generates in the app before sending to fetchr.