### PR TITLE
use 500 as default status code for errors, instead of 400

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ fetcher.updateOptions({
 
 ## Error Handling
 
-When an error occurs in your Fetchr CRUD method, you should return an error object to the callback. The error object should contain a `statusCode` (default 400) and `output` property that contains a JSON serializable object which will be sent to the client.
+When an error occurs in your Fetchr CRUD method, you should return an error object to the callback. The error object should contain a `statusCode` (default 500) and `output` property that contains a JSON serializable object which will be sent to the client.
 
 ```js
 module.exports = {

--- a/libs/fetcher.js
+++ b/libs/fetcher.js
@@ -50,7 +50,7 @@ function sanitizeResourceName(resource) {
  * @return {Object} object with resolved statusCode & output
  */
 function getErrorResponse(err) {
-    var statusCode = err.statusCode || 400;
+    var statusCode = err.statusCode || 500;
     var output = {
         message: 'request failed'
     };
@@ -571,7 +571,7 @@ module.exports = Fetcher;
 /**
  * @callback Fetcher~fetcherCallback
  * @param {Object} err  The request error, pass null if there was no error. The data and meta parameters will be ignored if this parameter is not null.
- * @param {number} [err.statusCode=400] http status code to return
+ * @param {number} [err.statusCode=500] http status code to return
  * @param {string} [err.message=request failed] http response body
  * @param {Object} data request result
  * @param {Object} [meta] request meta-data

--- a/tests/unit/libs/fetcher.js
+++ b/tests/unit/libs/fetcher.js
@@ -245,27 +245,27 @@ describe('Server Fetcher', function () {
             };
 
             it('should respond to POST api request with default error details',
-               makePostApiErrorTest({}, 400, {message: 'request failed'}));
+               makePostApiErrorTest({}, 500, {message: 'request failed'}));
 
             it('should respond to POST api request with custom error status code',
-               makePostApiErrorTest({statusCode: 500}, 500, {message: 'request failed'}));
+               makePostApiErrorTest({statusCode: 400}, 400, {message: 'request failed'}));
 
             it('should respond to POST api request with custom error message',
-               makePostApiErrorTest({message: 'Error message...'}, 400, {message: 'Error message...'}));
+               makePostApiErrorTest({message: 'Error message...'}, 500, {message: 'Error message...'}));
 
             it('should respond to POST api request with no leaked error information',
-               makePostApiErrorTest({statusCode: 500, danger: 'zone'}, 500, {message: 'request failed'}));
+               makePostApiErrorTest({statusCode: 400, danger: 'zone'}, 400, {message: 'request failed'}));
 
 
             describe('should respond to POST api request with custom output', function() {
                 it('using json object',
-                   makePostApiErrorTest({statusCode: 500, output: {
+                   makePostApiErrorTest({statusCode: 400, output: {
                       message: 'custom message',
                       foo    : 'bar',
-                   }}, 500, {message: 'custom message', 'foo': 'bar'}));
+                   }}, 400, {message: 'custom message', 'foo': 'bar'}));
 
                 it('using json array',
-                   makePostApiErrorTest({statusCode: 500, output: [1, 2]}, 500, [1, 2]));
+                   makePostApiErrorTest({statusCode: 400, output: [1, 2]}, 400, [1, 2]));
             });
         });
 
@@ -508,26 +508,26 @@ describe('Server Fetcher', function () {
             };
 
             it('should respond to GET api request with default error details',
-               makeGetApiErrorTest({}, 400, {message: 'request failed'}));
+               makeGetApiErrorTest({}, 500, {message: 'request failed'}));
 
             it('should respond to GET api request with custom error status code',
-               makeGetApiErrorTest({statusCode: 500}, 500, {message: 'request failed'}));
+               makeGetApiErrorTest({statusCode: 400}, 400, {message: 'request failed'}));
 
             it('should respond to GET api request with no leaked error information',
-               makeGetApiErrorTest({statusCode: 500, danger: 'zone'}, 500, {message: 'request failed'}));
+               makeGetApiErrorTest({statusCode: 400, danger: 'zone'}, 400, {message: 'request failed'}));
 
             it('should respond to GET api request with custom error message',
-               makeGetApiErrorTest({message: 'Error message...'}, 400, {message: 'Error message...'}));
+               makeGetApiErrorTest({message: 'Error message...'}, 500, {message: 'Error message...'}));
 
             describe('should respond to GET api request with custom output', function() {
                 it('using json object',
-                   makeGetApiErrorTest({statusCode: 500, output: {
+                   makeGetApiErrorTest({statusCode: 400, output: {
                       message: 'custom message',
                       foo    : 'bar',
-                   }}, 500, {message: 'custom message', 'foo': 'bar'}));
+                   }}, 400, {message: 'custom message', 'foo': 'bar'}));
 
                 it('using json array',
-                   makeGetApiErrorTest({statusCode: 500, output: [1, 2]}, 500, [1, 2]));
+                   makeGetApiErrorTest({statusCode: 400, output: [1, 2]}, 400, [1, 2]));
             });
         });
 


### PR DESCRIPTION
400 is for client error.  Propose to use 500 instead.  Theoretically, this is a breaking change.  We can make it a non breaking change, by allowing people to configure default error code to return.  But don't think it is worth the trouble.  We can go 1.0 with this :)

@Vijar @mridgway @redonkulus 