### PR TITLE
Expose xhr object for aborts

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,32 @@ fetcher
     });
 ```
 
+## XHR Object
+
+The xhr object is returned by the `.end()` method as long as you're *not* chaining promises.
+This is useful if you want to abort a request before it is completed.
+
+```js
+var req = fetcher
+    .read('someData')
+    .params({id: ###})
+    .end(function (err, data, meta) {
+        // err.output will be { message: "Not found", more: "meta data" }
+    });
+// req is the xhr object
+req.abort();
+```
+
+However, you can't acces the xhr object if using promise chaining like so:
+```js
+var req = fetcher
+    .read('someData')
+    .params({id: ###})
+    .end();
+// req is a promise
+req.then(onResolve, onReject);
+```
+
 ## XHR Timeouts
 
 `xhrTimeout` is an optional config property that allows you to set timeout (in ms) for all clientside requests, defaults to `3000`.

--- a/libs/util/http.client.js
+++ b/libs/util/http.client.js
@@ -159,11 +159,11 @@ function doXhr(method, url, headers, data, config, callback) {
     if (data !== undefined && data !== NULL) {
         options.data = isContentTypeJSON(headers) ? JSON.stringify(data) : data;
     }
-    io(url, options);
+    return io(url, options);
 }
 
 function io(url, options) {
-    xhr({
+    return xhr({
         url: url,
         method: options.method || METHOD_GET,
         timeout: options.timeout,
@@ -233,7 +233,7 @@ module.exports = {
      * @param {Function} callback The callback function, with two params (error, response)
      */
     get : function (url, headers, config, callback) {
-        doXhr(METHOD_GET, url, headers, NULL, config, callback);
+        return doXhr(METHOD_GET, url, headers, NULL, config, callback);
     },
 
     /**
@@ -249,7 +249,7 @@ module.exports = {
      * @param {Function} callback The callback function, with two params (error, response)
      */
     put : function (url, headers, data, config, callback) {
-        doXhr(METHOD_PUT, url, headers, data, config, callback);
+        return doXhr(METHOD_PUT, url, headers, data, config, callback);
     },
 
     /**
@@ -266,7 +266,7 @@ module.exports = {
      * @param {Function} callback The callback function, with two params (error, response)
      */
     post : function (url, headers, data, config, callback) {
-        doXhr(METHOD_POST, url, headers, data, config, callback);
+        return doXhr(METHOD_POST, url, headers, data, config, callback);
     },
 
     /**
@@ -281,6 +281,6 @@ module.exports = {
      * @param {Function} callback The callback function, with two params (error, response)
      */
     'delete' : function (url, headers, config, callback) {
-        doXhr(METHOD_DELETE, url, headers, NULL, config, callback);
+        return doXhr(METHOD_DELETE, url, headers, NULL, config, callback);
     }
 };

--- a/tests/unit/libs/fetcher.client.js
+++ b/tests/unit/libs/fetcher.client.js
@@ -136,6 +136,52 @@ describe('Client Fetcher', function () {
         })
     });
 
+    describe('xhr', function () {
+        before(function () {
+            this.fetcher = new Fetcher({
+                context: context
+            });
+        });
+
+        it('should return xhr object when calling end w/ callback', function (done) {
+            var operation = 'create';
+            var xhr = this.fetcher
+                [operation](resource)
+                .params(params)
+                .body(body)
+                .clientConfig(config)
+                .end(callback(operation, function (err) {
+                    if (err) {
+                        done(err);
+                        return;
+                    }
+                    console.log(xhr.readyState);
+                    expect(xhr.readyState).to.exist;
+                    expect(xhr.abort).to.exist;
+                    expect(xhr.open).to.exist;
+                    expect(xhr.send).to.exist;
+                    done();
+                }));
+        });
+        it('should be able to abort xhr when calling end w/ callback', function (done) {
+            var operation = 'create';
+            var xhr = this.fetcher
+                [operation](resource)
+                .params(params)
+                .body(body)
+                .clientConfig(config)
+                .end(callback(operation, function (err) {
+                    if (err) {
+                        // in this case, an error is good
+                        // we want the error to be thrown then request is aborted
+                        done();
+                    }
+                }));
+            expect(xhr.abort).to.exist;
+            xhr.abort();
+        });
+    });
+
     describe('xhrTimeout', function () {
         var DEFAULT_XHR_TIMEOUT = 3000;
 


### PR DESCRIPTION
@redonkulus @mridgway @praveenbnsm

We actually can expose the xhr object with little effort, but it just won't work with our promise interface though.

Fixes #142 