### PR TITLE
Returning rejected Promise when error occurred

### DIFF
--- a/libs/fetcher.client.js
+++ b/libs/fetcher.client.js
@@ -152,7 +152,9 @@ Request.prototype.end = function (callback) {
             debug('Executing request %s.%s with params %o and body %o', self.resource, self.operation, self._params, self._body);
             setImmediate(executeRequest, self, resolve, reject);
         });
-        promise = promise.then(captureMeta, captureMeta);
+        promise = promise.then(captureMeta, function (err) {
+            throw captureMeta(err);
+        });
         return promise;
     }
 };

--- a/tests/util/testCrud.js
+++ b/tests/util/testCrud.js
@@ -187,28 +187,55 @@ module.exports = function testCrud (params, body, config, callback, resolve, rej
                 });
             });
         });
-        it('should have serviceMeta data on error', function (done) {
-            var fetcher = this.fetcher;
-            fetcher._serviceMeta.length = 0; // reset serviceMeta to empty array
-            fetcher
-            .read(mockErrorService.name)
-            .params(_.merge({}, params, {
-                meta: {
-                    headers: {
-                        'x-foo': 'foo'
-                    }
-                }
-            }))
-            .clientConfig(config)
-            .end(function (err) {
-                if (err) {
-                    var serviceMeta = fetcher.getServiceMeta();
-                    expect(serviceMeta).to.have.length(1);
-                    expect(serviceMeta[0]).to.include.keys('headers');
-                    expect(serviceMeta[0].headers).to.include.keys('x-foo');
-                    expect(serviceMeta[0].headers['x-foo']).to.equal('foo');
-                    done();
-                }
+        describe('should have serviceMeta data on error', function() {
+            it('with callbacks', function (done) {
+                var fetcher = this.fetcher;
+                fetcher._serviceMeta.length = 0; // reset serviceMeta to empty array
+                fetcher
+                  .read(mockErrorService.name)
+                  .params(_.merge({}, params, {
+                      meta: {
+                          headers: {
+                              'x-foo': 'foo'
+                          }
+                      }
+                  }))
+                  .clientConfig(config)
+                  .end(function (err) {
+                      if (err) {
+                          var serviceMeta = fetcher.getServiceMeta();
+                          expect(serviceMeta).to.have.length(1);
+                          expect(serviceMeta[0]).to.include.keys('headers');
+                          expect(serviceMeta[0].headers).to.include.keys('x-foo');
+                          expect(serviceMeta[0].headers['x-foo']).to.equal('foo');
+                          done();
+                      }
+                  });
+            });
+            it('with Promises', function (done) {
+                var fetcher = this.fetcher;
+                fetcher._serviceMeta.length = 0; // reset serviceMeta to empty array
+                fetcher
+                  .read(mockErrorService.name)
+                  .params(_.merge({}, params, {
+                      meta: {
+                          headers: {
+                              'x-foo': 'foo'
+                          }
+                      }
+                  }))
+                  .clientConfig(config)
+                  .end()
+                  .catch(function (err) {
+                      if (err) {
+                          var serviceMeta = fetcher.getServiceMeta();
+                          expect(serviceMeta).to.have.length(1);
+                          expect(serviceMeta[0]).to.include.keys('headers');
+                          expect(serviceMeta[0].headers).to.include.keys('x-foo');
+                          expect(serviceMeta[0].headers['x-foo']).to.equal('foo');
+                          done();
+                      }
+                  });
             });
         });
     });


### PR DESCRIPTION
if the Promise's catch handler returns just a value, the Promise becomes fulfilled. So, it should return a rejected Promises.