### PR TITLE
Invalid resource error handling

### DIFF
--- a/libs/fetcher.js
+++ b/libs/fetcher.js
@@ -189,7 +189,13 @@ function executeRequest (request, resolve, reject) {
     if ((op === OP_CREATE) || (op === OP_UPDATE)) {
         args.splice(3, 0, request._body);
     }
-    var service = Fetcher.getService(request.resource);
+    var service;
+    try {
+        service = Fetcher.getService(request.resource);
+    } catch (err) {
+        reject({err: err});
+        return;
+    }
     service[op].apply(service, args);
 }
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "cover": "istanbul cover --dir artifacts -- ./node_modules/mocha/bin/_mocha tests/unit/ --recursive --reporter spec",
     "lint": "jshint libs tests",
-    "test": "mocha tests/unit/ --recursive --reporter spec"
+    "test": "NODE_ENV=test mocha tests/unit/ --recursive --reporter spec"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
In a server-side fetcher, there is currently no way to handle any error that's thrown by `Fetcher.getService` (since it gets executed via `setImmediate` inside of a promise constructor).
In particular, if you specify an invalid resource name (and that's easy to do for the new people on team in a substantially complex app), an error ends up in `uncaughtException` handler (or crashes the server).