### PR TITLE
be defensive. result could be null

### DIFF
--- a/libs/fetcher.client.js
+++ b/libs/fetcher.client.js
@@ -166,7 +166,7 @@ Request.prototype.end = function (callback) {
     if (callback) {
         return executeRequest(self, function requestSucceeded(result) {
             self._captureMetaAndStats(null, result);
-            setImmediate(callback, null, result.data, result.meta);
+            setImmediate(callback, null, result && result.data, result && result.meta);
         }, function requestFailed(err) {
             self._captureMetaAndStats(err);
             setImmediate(callback, err);


### PR DESCRIPTION
`result` is parsed by [`parseResponse()`](https://github.com/yahoo/fetchr/compare/defensive?expand=1#diff-84c4f8c88b61ef0647afbcf02f0ae99cR30), which could return `null`