### PR TITLE
check service operation is defined

### DIFF
--- a/libs/fetcher.js
+++ b/libs/fetcher.js
@@ -223,11 +223,13 @@ function executeRequest (request, resolve, reject) {
     var service;
     try {
         service = Fetcher.getService(request.resource);
+        if (!service[op]) {
+          throw new Error('operation: ' + op + ' is undefined on service: ' + request.resource);
+        }
+        service[op].apply(service, args);
     } catch (err) {
         reject({err: err});
-        return;
     }
-    service[op].apply(service, args);
 }
 
 /**

--- a/tests/mock/MockNoopService.js
+++ b/tests/mock/MockNoopService.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright 2016, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
+var lodash = require('lodash');
+var MockNoopService = {
+    name: 'mock_noop_service',
+};
+
+module.exports = MockNoopService;

--- a/tests/mock/mockApp.js
+++ b/tests/mock/mockApp.js
@@ -11,8 +11,10 @@ var app = express();
 var FetcherServer = require('../../libs/fetcher');
 var mockService = require('./MockService');
 var mockErrorService = require('./MockErrorService');
+var mockNoopService = require('./MockNoopService');
 FetcherServer.registerService(mockService);
 FetcherServer.registerService(mockErrorService);
+FetcherServer.registerService(mockNoopService);
 
 app.use(bodyParser.json());
 app.use(DEFAULT_XHR_PATH, FetcherServer.middleware());

--- a/tests/mock/mockCorsApp.js
+++ b/tests/mock/mockCorsApp.js
@@ -9,8 +9,10 @@ var app = express();
 var FetcherServer = require('../../libs/fetcher');
 var mockService = require('./MockService');
 var mockErrorService = require('./MockErrorService');
+var mockNoopService = require('./MockNoopService');
 FetcherServer.registerService(mockService);
 FetcherServer.registerService(mockErrorService);
+FetcherServer.registerService(mockNoopService);
 
 app.use(bodyParser.json());
 app.use(function cors (req, res, next) {

--- a/tests/unit/libs/fetcher.js
+++ b/tests/unit/libs/fetcher.js
@@ -13,6 +13,7 @@ var Fetcher = require('../../../libs/fetcher');
 var fetcher;
 var mockService = require('../../mock/MockService');
 var mockErrorService = require('../../mock/MockErrorService');
+var mockNoopService = require('../../mock/MockNoopService');
 var qs = require('querystring');
 var testCrud = require('../../util/testCrud');
 
@@ -20,6 +21,7 @@ describe('Server Fetcher', function () {
     beforeEach(function () {
         Fetcher.registerService(mockService);
         Fetcher.registerService(mockErrorService);
+        Fetcher.registerService(mockNoopService);
     });
     afterEach(function () {
         Fetcher.services = {}; // reset services

--- a/tests/util/testCrud.js
+++ b/tests/util/testCrud.js
@@ -3,6 +3,7 @@ var defaultOptions = require('./defaultOptions');
 var resource = defaultOptions.resource;
 var invalidResource = 'invalid_resource';
 var mockErrorService = require('../mock/MockErrorService');
+var mockNoopService = require('../mock/MockNoopService');
 var _ = require('lodash');
 module.exports = function testCrud (params, body, config, callback, resolve, reject) {
     var options = {};
@@ -317,6 +318,31 @@ module.exports = function testCrud (params, body, config, callback, resolve, rej
                       }
                   });
             });
+        });
+    });
+    describe('should reject no operation service', function() {
+        it('with callback', function(done) {
+            var fetcher = this.fetcher;
+            fetcher
+              .read(mockNoopService.name)
+              .clientConfig(config)
+              .end(function(err) {
+                expect(err.name).to.equal('Error');
+                expect(err.message).to.contain('operation: read is undefined on service: mock_noop_service');
+                done();
+              });
+        });
+        it('with Promise', function(done) {
+            var fetcher = this.fetcher;
+            fetcher
+              .read(mockNoopService.name)
+              .clientConfig(config)
+              .end()
+              .catch(function (err) {
+                expect(err.name).to.equal('Error');
+                expect(err.message).to.contain('operation: read is undefined on service: mock_noop_service');
+                done();
+              });
         });
     });
 };


### PR DESCRIPTION
`service[op].apply(service, args)` throws exception when `service[op]` is undefined.
And this task is called under `setImmediate`, so if service does not have the specified operation, `process.on('uncaughtException')` will be thrown. 

This PR is to avoid the above situation. 