### PR TITLE
prevent unsupported operation call

### DIFF
--- a/libs/fetcher.js
+++ b/libs/fetcher.js
@@ -6,6 +6,7 @@
 var OP_READ = 'read';
 var OP_CREATE = 'create';
 var OP_UPDATE = 'update';
+var OP_DELETE = 'delete';
 var GET = 'GET';
 var qs = require('querystring');
 var debug = require('debug')('Fetchr');
@@ -223,7 +224,7 @@ function executeRequest (request, resolve, reject) {
     var service;
     try {
         service = Fetcher.getService(request.resource);
-        if (!service[op]) {
+        if ([OP_CREATE,OP_READ,OP_UPDATE,OP_DELETE].indexOf(op) < 0 || !service[op]) {
           throw new Error('operation: ' + op + ' is undefined on service: ' + request.resource);
         }
         service[op].apply(service, args);

--- a/libs/fetcher.js
+++ b/libs/fetcher.js
@@ -88,13 +88,6 @@ function Request (operation, resource, options) {
         throw new Error('Resource is required for a fetcher request');
     }
 
-    if(operation) {
-        if (operation !== OP_CREATE && operation !== OP_READ
-            && operation !== OP_UPDATE && operation !== OP_DELETE) {
-            throw new Error('Unsupported operation');
-        }
-    }
-
     this.operation = operation || OP_READ;
     this.resource = resource;
     options = options || {};
@@ -429,20 +422,20 @@ Fetcher.middleware = function (options) {
                 error.source = 'fetchr';
                 return next(error);
             }
-            serviceMeta = [];
-            try {
-                request = new Request(singleRequest.operation, singleRequest.resource, {
-                    req: req,
-                    serviceMeta: serviceMeta,
-                    statsCollector: options.statsCollector
-                });
-            }catch(err){
+            var operation = singleRequest.operation;
+            if(operation !== OP_CREATE && operation !== OP_UPDATE && operation !== OP_DELETE && operation !== OP_READ) {
                 error = fumble.http.badRequest('Invalid Fetchr Access', {
-                    debug: err.message
+                    debug: 'Unsupported operation : operation must be create or read or update or delete'
                 });
                 error.source = 'fetchr';
                 return next(error);
             }
+            serviceMeta = [];
+            request = new Request(operation, singleRequest.resource, {
+                req: req,
+                serviceMeta: serviceMeta,
+                statsCollector: options.statsCollector
+            });
             request
                 .params(singleRequest.params)
                 .body(singleRequest.body || {})

--- a/tests/unit/libs/fetcher.js
+++ b/tests/unit/libs/fetcher.js
@@ -599,6 +599,16 @@ describe('Server Fetcher', function () {
                     }
                 }}, 'Bad resource invalid*Service', done);
             });
+            it('should handle unsupported operation', function (done) {
+                makeInvalidReqTest({method: 'POST', body: {
+                    requests: {
+                        g0: {
+                            resource: mockErrorService.name,
+                            operation: 'constructor'
+                        }
+                    }
+                }}, 'Unsupported operation', done);
+            });
             it('should skip POST request with empty req.body.requests object', function (done) {
                 makeInvalidReqTest({method: 'POST', body: { requests: {}}}, 'No resources', done);
             });

--- a/tests/unit/libs/fetcher.js
+++ b/tests/unit/libs/fetcher.js
@@ -607,7 +607,7 @@ describe('Server Fetcher', function () {
                             operation: 'constructor'
                         }
                     }
-                }}, 'Unsupported operation', done);
+                }}, 'Unsupported operation : operation must be create or read or update or delete', done);
             });
             it('should skip POST request with empty req.body.requests object', function (done) {
                 makeInvalidReqTest({method: 'POST', body: { requests: {}}}, 'No resources', done);


### PR DESCRIPTION
I think fetcher.js should allow only 'read,create,update,delete' operations that fetchr.client supports.

because I could call any operation like 'constructor'. this may cause serious security problem.

```
curl -X POST http://localhost:3000/proxy -H "Content-Type:application/json" -d '{ "context":{},"requests":{ "g0": {"resource": "bookmarking", "operation": "constructor", "params":{}}}}' 
```