### PR TITLE
Improve error message in case of timeout

### DIFF
--- a/libs/util/http.client.js
+++ b/libs/util/http.client.js
@@ -211,6 +211,9 @@ function io(url, options) {
         resp.responseText = body;
 
         if (err) {
+            if (err.message === 'XMLHttpRequest timeout') {
+                err = new Error('XMLHttpRequest timeout: failed to load ' + resp.url + ' in ' + options.timeout + 'ms');
+            }
             // getting detail info from xhr module
             err.rawRequest = resp.rawRequest;
             err.url = resp.url;


### PR DESCRIPTION
Currently the upstream error message in case of a timeout is not very helpful. So I’ve extended the message to include the `url` and the `timeout`.