### PR TITLE
Always set timeout property for error object

### DIFF
--- a/libs/util/http.client.js
+++ b/libs/util/http.client.js
@@ -203,9 +203,6 @@ function io(url, options) {
                 err.output = err.body.output;
                 err.meta = err.body.meta;
             }
-            if (408 === status || 0 === status) {
-                err.timeout = options.timeout;
-            }
         }
 
         resp.responseText = body;
@@ -214,6 +211,8 @@ function io(url, options) {
             // getting detail info from xhr module
             err.rawRequest = resp.rawRequest;
             err.url = resp.url;
+            err.timeout = options.timeout;
+
             options.on.failure.call(null, err, resp);
         } else {
             options.on.success.call(null, null, resp);

--- a/tests/unit/libs/util/http.client.js
+++ b/tests/unit/libs/util/http.client.js
@@ -12,6 +12,7 @@ var http;
 var xhrOptions;
 var mockResponse;
 var mockBody = '';
+var mockError = null;
 
 describe('Client HTTP', function () {
 
@@ -24,7 +25,7 @@ describe('Client HTTP', function () {
         mockBody = '';
         mockery.registerMock('xhr', function mockXhr(options, callback) {
             xhrOptions.push(options);
-            callback(null, mockResponse, mockBody);
+            callback(mockError, mockResponse, mockBody);
         });
         http = require('../../../../libs/util/http.client.js');
     });
@@ -32,6 +33,10 @@ describe('Client HTTP', function () {
     after(function() {
         mockBody = '';
         mockery.deregisterAll();
+    });
+
+    afterEach(function () {
+        mockError = null;
     });
 
     describe('#Successful requests', function () {
@@ -361,6 +366,23 @@ describe('Client HTTP', function () {
                     expect(options.timeout).to.equal(6000);
                     done();
                 });
+            });
+        });
+    });
+
+    describe('xhr errors', function () {
+        it('should pass-through any xhr error', function (done) {
+            mockError = new Error('AnyError');
+            xhrOptions = [];
+            mockResponse = { statusCode: 0, url: '/url' };
+
+            http.get('/url', {}, { xhrTimeout: 42 }, function (err, response) {
+                expect(response).to.equal(undefined);
+                expect(err.message).to.equal('AnyError');
+                expect(err.timeout).to.equal(42);
+                expect(err.url).to.equal('/url');
+
+                done();
             });
         });
     });


### PR DESCRIPTION
As figured out in #175 `err.timeout` was only set when there was a `408` response but not when the `xhr` callback receives a timeout error.