### PR TITLE
fix ie11 regression on fetcher.client.js

### DIFF
--- a/libs/fetcher.client.js
+++ b/libs/fetcher.client.js
@@ -52,30 +52,25 @@ function pickContext (context, picker, method) {
     }
 
     var p = picker[method];
+    var result = {};
 
     if (typeof p === 'string') {
-        return { [p]: context[p] };
-    }
-
-    if (Array.isArray(p)) {
-        var pc = {}
+        result[p] = context[p];
+    } else if (Array.isArray(p)) {
         p.forEach(function(key) {
-            pc[key] = context[key];
+            result[key] = context[key];
         });
-        return pc;
-    }
-
-    if (typeof p === 'function') {
-        var pc = {};
+    } else if (typeof p === 'function') {
         forEach(context, function(value, key) {
             if (p(value, key, context)) {
-                pc[key] = context[key];
+                result[key] = context[key];
             }
         })
-        return pc;
+    } else {
+        throw new TypeError('picker must be an string, an array, or a function.');
     }
 
-    throw new TypeError('picker must be an string, an array, or a function.');
+    return result;
 }
 
 /**


### PR DESCRIPTION
The problem was on the following code:

```
    return { [p]: context[p] };
```

ie11 doesn't support this shortcut and sees it as syntax error. I wan the script on ie11 on win7 and I don't get any syntax error anymore.

Solves #251 


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
