### PR TITLE
Improve retry mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,8 +432,7 @@ For requests from the server, the config object is simply passed into the servic
 
 ## Retry
 
-You can set Fetchr to retry failed requests automatically by setting a
-`retry` settings in the client configuration:
+You can set Fetchr to retry failed requests automatically by setting a `retry` settings in the client configuration:
 
 ```js
 fetcher

--- a/README.md
+++ b/README.md
@@ -446,9 +446,7 @@ fetcher
     .end();
 ```
 
-With this confiugration, Fetchr will retry all requests that fails
-with 408 status code or with a XHR 0 status code for 2 more times
-before returning an error. The interval between each requests respects
+With this configuration, Fetchr will retry all requests that fail with 408 status code or with an XHR 0 status code two more times before returning an error. The interval between each request respects
 the following formula, based on the exponential backoff and full jitter strategy published in [this AWS architecture blog post](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/):
 
 ```js

--- a/README.md
+++ b/README.md
@@ -430,6 +430,69 @@ fetcher.read('service').params({ id: 1 }).clientConfig(config).end(callbackFn);
 
 For requests from the server, the config object is simply passed into the service being called.
 
+## Retry
+
+You can set Fetchr to retry failed requests automatically by setting a
+`retry` settings in the client configuration:
+
+```js
+fetcher
+    .read('service')
+    .clientConfig({
+        retry: {
+            maxRetries: 2,
+        },
+    })
+    .end();
+```
+
+With this confiugration, Fetchr will retry all requests that fails
+with 408 status code or with a XHR 0 status code for 2 more times
+before returning an error. The interval between each requests respects
+the folowwing formula:
+
+```js
+Math.random() * Math.pow(2, attempt) * interval;
+```
+
+`attempt` is the number of the current retry attempt starting
+from 0. By default `interval` corresponds to 200ms.
+
+You can customize the retry behavior by adding more properties in the
+`retry` object:
+
+```js
+fetcher
+    .read('resource')
+    .clientConfig({
+        retry: {
+            maxRetries: 5,
+            interval: 1000,
+            statusCodes: [408, 502],
+        },
+    })
+    .end();
+```
+
+With the above configuration, Fetchr will retry for at maxiumum of 5
+times all the requests that fails with a 408 or 502 status code. The
+interval between each request will still use the formula from above,
+but the interval of 1000ms will be used instead.
+
+**Note:** Fetchr doesn't retry POST requests for safety reasons. You
+can enable retries for POST requests by setting the `unsafeAllowRetry`
+property to `true`:
+
+```js
+fetcher
+    .create('resource')
+    .clientConfig({
+        retry: { maxRetries: 2 },
+        unsafeAllowRetry: true,
+    })
+    .end();
+```
+
 ## Context Variables
 
 By Default, fetchr appends all context values to the xhr url as query params. `contextPicker` allows you to greater control over which context variables get sent as query params depending on the xhr method (`GET` or `POST`). This is useful when you want to limit the number of variables in a `GET` url in order not to accidentally [cache bust](http://webassets.readthedocs.org/en/latest/expiring.html).

--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ fetcher
 With this confiugration, Fetchr will retry all requests that fails
 with 408 status code or with a XHR 0 status code for 2 more times
 before returning an error. The interval between each requests respects
-the folowwing formula:
+the following formula, based on the exponential backoff and full jitter strategy published in [this AWS architecture blog post](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/):
 
 ```js
 Math.random() * Math.pow(2, attempt) * interval;

--- a/README.md
+++ b/README.md
@@ -472,14 +472,9 @@ fetcher
     .end();
 ```
 
-With the above configuration, Fetchr will retry for at maxiumum of 5
-times all the requests that fails with a 408 or 502 status code. The
-interval between each request will still use the formula from above,
-but the interval of 1000ms will be used instead.
+With the above configuration, Fetchr will retry all failed (408 or 502 status code) requests for a maximum of 5 times. The interval between each request will still use the formula from above, but the interval of 1000ms will be used instead.
 
-**Note:** Fetchr doesn't retry POST requests for safety reasons. You
-can enable retries for POST requests by setting the `unsafeAllowRetry`
-property to `true`:
+**Note:** Fetchr doesn't retry POST requests for safety reasons. You can enable retries for POST requests by setting the `unsafeAllowRetry` property to `true`:
 
 ```js
 fetcher

--- a/libs/util/http.client.js
+++ b/libs/util/http.client.js
@@ -151,6 +151,11 @@ function doXhr(method, url, headers, data, config, attempt, callback) {
                 ) {
                     callback(err);
                 } else {
+                    var delay =
+                        Math.random() *
+                        config.retry.interval *
+                        Math.pow(2, attempt);
+
                     setTimeout(function retryXHR() {
                         doXhr(
                             method,
@@ -161,7 +166,7 @@ function doXhr(method, url, headers, data, config, attempt, callback) {
                             attempt + 1,
                             callback
                         );
-                    }, config.retry.interval * Math.pow(2, attempt));
+                    }, delay);
                 }
             },
         },

--- a/libs/util/http.client.js
+++ b/libs/util/http.client.js
@@ -22,6 +22,7 @@ var DEFAULT_CONFIG = {
             maxRetries: 0,
             statusCodes: [0, 408, 999],
         },
+        unsafeAllowRetry: false,
     },
     CONTENT_TYPE = 'Content-Type',
     TYPE_JSON = 'application/json',

--- a/libs/util/http.client.js
+++ b/libs/util/http.client.js
@@ -255,9 +255,10 @@ module.exports = {
      * @param {Object} headers
      * @param {Object} config  The config object.
      * @param {Number} [config.timeout=3000] Timeout (in ms) for each request
-     * @param {Object} config.retry   Retry config object.
-     * @param {Number} [config.retry.interval=200]  The start interval unit (in ms).
-     * @param {Number} [config.retry.max_retries=2]   Number of max retries.
+     * @param {Object} config.retry Retry config object.
+     * @param {Number} [config.retry.interval=200] The start interval unit (in ms).
+     * @param {Number} [config.retry.maxRetries=0] Number of max retries.
+     * @param {Number} [config.retry.statusCodes=[0, 408, 999]] Response status codes to be retried.
      * @param {Boolean} [config.cors] Whether to enable CORS & use XDR on IE8/9.
      * @param {Function} callback The callback function, with two params (error, response)
      */
@@ -280,8 +281,9 @@ module.exports = {
      * @param {Mixed}  data
      * @param {Object} config  The config object. No retries for PUT.
      * @param {Number} [config.timeout=3000] Timeout (in ms) for each request
-     * @param {Number} [config.retry.interval=200]  The start interval unit (in ms).
-     * @param {Number} [config.retry.max_retries=2]   Number of max retries.
+     * @param {Number} [config.retry.interval=200] The start interval unit (in ms).
+     * @param {Number} [config.retry.maxRetries=0] Number of max retries.
+     * @param {Number} [config.retry.statusCodes=[0, 408, 999]] Response status codes to be retried.
      * @param {Boolean} [config.cors] Whether to enable CORS & use XDR on IE8/9.
      * @param {Function} callback The callback function, with two params (error, response)
      */
@@ -305,8 +307,9 @@ module.exports = {
      * @param {Object} config  The config object. No retries for POST.
      * @param {Number} [config.timeout=3000] Timeout (in ms) for each request
      * @param {Boolean} [config.unsafeAllowRetry=false] Whether to allow retrying this post.
-     * @param {Number} [config.retry.interval=200]  The start interval unit (in ms).
-     * @param {Number} [config.retry.max_retries=2]   Number of max retries.
+     * @param {Number} [config.retry.interval=200] The start interval unit (in ms).
+     * @param {Number} [config.retry.maxRetries=0] Number of max retries.
+     * @param {Number} [config.retry.statusCodes=[0, 408, 999]] Response status codes to be retried.
      * @param {Boolean} [config.cors] Whether to enable CORS & use XDR on IE8/9.
      * @param {Function} callback The callback function, with two params (error, response)
      */
@@ -328,8 +331,9 @@ module.exports = {
      * @param {Object} headers
      * @param {Object} config  The config object. No retries for DELETE.
      * @param {Number} [config.timeout=3000] Timeout (in ms) for each request
-     * @param {Number} [config.retry.interval=200]  The start interval unit (in ms).
-     * @param {Number} [config.retry.max_retries=2]   Number of max retries.
+     * @param {Number} [config.retry.interval=200] The start interval unit (in ms).
+     * @param {Number} [config.retry.maxRetries=0] Number of max retries.
+     * @param {Number} [config.retry.statusCodes=[0, 408, 999]] Response status codes to be retried.
      * @param {Boolean} [config.cors] Whether to enable CORS & use XDR on IE8/9.
      * @param {Function} callback The callback function, with two params (error, response)
      */

--- a/libs/util/http.client.js
+++ b/libs/util/http.client.js
@@ -19,7 +19,7 @@ var forEach = require('./forEach');
 var DEFAULT_CONFIG = {
         retry: {
             interval: 200,
-            max_retries: 0,
+            maxRetries: 0,
             statusCodes: [0, 408, 999],
         },
     },
@@ -74,7 +74,7 @@ function isContentTypeJSON(headers) {
 }
 
 function shouldRetry(method, config, statusCode, attempt) {
-    if (attempt >= config.retry.max_retries) {
+    if (attempt >= config.retry.maxRetries) {
         return false;
     }
 
@@ -91,33 +91,41 @@ function shouldRetry(method, config, statusCode, attempt) {
 
 function mergeConfig(config) {
     var cfg = {
-            unsafeAllowRetry: config.unsafeAllowRetry || false,
-            retry: {
-                interval: DEFAULT_CONFIG.retry.interval,
-                max_retries: DEFAULT_CONFIG.retry.max_retries,
-                statusCodes: DEFAULT_CONFIG.retry.statusCodes,
-            },
-        }, // Performant-but-verbose way of cloning the default config as base
-        timeout,
-        interval,
-        maxRetries;
+        unsafeAllowRetry: config.unsafeAllowRetry || false,
+        retry: {
+            interval: DEFAULT_CONFIG.retry.interval,
+            maxRetries: DEFAULT_CONFIG.retry.maxRetries,
+            statusCodes: DEFAULT_CONFIG.retry.statusCodes,
+        },
+    };
 
     if (config) {
-        timeout = config.timeout || config.xhrTimeout;
+        var timeout = config.timeout || config.xhrTimeout;
         timeout = parseInt(timeout, 10);
         if (!isNaN(timeout) && timeout > 0) {
             cfg.timeout = timeout;
         }
 
         if (config.retry) {
-            interval = parseInt(config.retry.interval, 10);
+            var interval = parseInt(config.retry.interval, 10);
             if (!isNaN(interval) && interval > 0) {
                 cfg.retry.interval = interval;
             }
-            maxRetries = parseInt(config.retry.max_retries, 10);
-            if (!isNaN(maxRetries) && maxRetries >= 0) {
-                cfg.retry.max_retries = maxRetries;
+
+            if (config.retry.max_retries !== undefined) {
+                console.warn(
+                    '"max_retries" is deprecated and will be removed in a future release, use "maxRetries" instead.'
+                );
             }
+
+            var maxRetries = parseInt(
+                config.retry.max_retries || config.retry.maxRetries,
+                10
+            );
+            if (!isNaN(maxRetries) && maxRetries >= 0) {
+                cfg.retry.maxRetries = maxRetries;
+            }
+
             if (config.retry.statusCodes) {
                 cfg.retry.statusCodes = config.retry.statusCodes;
             }

--- a/libs/util/http.client.js
+++ b/libs/util/http.client.js
@@ -20,6 +20,7 @@ var DEFAULT_CONFIG = {
         retry: {
             interval: 200,
             max_retries: 0,
+            statusCodes: [0, 408, 999],
         },
     },
     CONTENT_TYPE = 'Content-Type',
@@ -85,11 +86,7 @@ function shouldRetry(method, config, statusCode, attempt) {
         return false;
     }
 
-    if (statusCode !== 0 && statusCode !== 408 && statusCode !== 999) {
-        return false;
-    }
-
-    return true;
+    return config.retry.statusCodes.indexOf(statusCode) !== -1;
 }
 
 function mergeConfig(config) {
@@ -98,6 +95,7 @@ function mergeConfig(config) {
             retry: {
                 interval: DEFAULT_CONFIG.retry.interval,
                 max_retries: DEFAULT_CONFIG.retry.max_retries,
+                statusCodes: DEFAULT_CONFIG.retry.statusCodes,
             },
         }, // Performant-but-verbose way of cloning the default config as base
         timeout,
@@ -119,6 +117,9 @@ function mergeConfig(config) {
             maxRetries = parseInt(config.retry.max_retries, 10);
             if (!isNaN(maxRetries) && maxRetries >= 0) {
                 cfg.retry.max_retries = maxRetries;
+            }
+            if (config.retry.statusCodes) {
+                cfg.retry.statusCodes = config.retry.statusCodes;
             }
         }
 

--- a/libs/util/http.client.js
+++ b/libs/util/http.client.js
@@ -160,6 +160,7 @@ function doXhr(method, url, headers, data, config, attempt, callback) {
                 ) {
                     callback(err);
                 } else {
+                    // Use exponential backoff and full jitter strategy published in https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
                     var delay =
                         Math.random() *
                         config.retry.interval *

--- a/tests/unit/libs/util/http.client.js
+++ b/tests/unit/libs/util/http.client.js
@@ -316,7 +316,7 @@ describe('Client HTTP', function () {
                     timeout: 2000,
                     retry: {
                         interval: 200,
-                        max_retries: 1,
+                        maxRetries: 1,
                     },
                 },
                 function (err) {
@@ -348,7 +348,7 @@ describe('Client HTTP', function () {
                     timeout: 2000,
                     retry: {
                         interval: 20,
-                        max_retries: 1,
+                        maxRetries: 1,
                         statusCodes: [502],
                     },
                 },

--- a/tests/unit/libs/util/http.client.js
+++ b/tests/unit/libs/util/http.client.js
@@ -282,7 +282,7 @@ describe('Client HTTP', function () {
         });
     });
 
-    describe('#408 requests', function () {
+    describe('#Retry', function () {
         beforeEach(function () {
             xhrOptions = [];
             mockBody = 'BODY';
@@ -332,6 +332,28 @@ describe('Client HTTP', function () {
                     expect(err.message).to.equal('BODY');
                     expect(err.statusCode).to.equal(408);
                     expect(err.body).to.equal('BODY');
+                    expect(xhrOptions[0]).to.eql(xhrOptions[1]);
+                    done();
+                }
+            );
+        });
+
+        it('GET with retry and custom status code', function (done) {
+            mockResponse = { statusCode: 502 };
+
+            http.get(
+                '/url',
+                { 'X-Foo': 'foo' },
+                {
+                    timeout: 2000,
+                    retry: {
+                        interval: 20,
+                        max_retries: 1,
+                        statusCodes: [502],
+                    },
+                },
+                function () {
+                    expect(xhrOptions.length).to.equal(2);
                     expect(xhrOptions[0]).to.eql(xhrOptions[1]);
                     done();
                 }


### PR DESCRIPTION
@redonkulus while thinking in a way of adding retry mechanism to fetchr to solve an issue in my company, I discovered that fetchr already has support for it. I went deeper on it and realized that there was a bug with the retry interval and that the status code check was only supporting 408 and xhr failures. Then I fixed the bug and add support for custom status while keeping it backward compatible.

- fix initial retry.interval not being respected
- add support for custom response status codes to be retried automatically

**UPDATE:**
- add full jitter formula for interval calculation
- deprecate `max_retries` in favor of `maxRetries` 
- add documentation

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
