### PR TITLE
http: remove trim polyfill

### DIFF
--- a/libs/util/http.client.js
+++ b/libs/util/http.client.js
@@ -30,13 +30,6 @@ var DEFAULT_CONFIG = {
 
 var forEach = require('./forEach');
 
-//trim polyfill, maybe pull from npm later
-if (!String.prototype.trim) {
-    String.prototype.trim = function () {
-        return this.replace(/^\s+|\s+$/g, '');
-    };
-}
-
 function normalizeHeaders(headers, method, isCors) {
     var normalized = {};
     if (!isCors) {


### PR DESCRIPTION
@redonkulus `String.prototype.trim` was added in IE9. IE8 was deprecated by MS [in 2016](https://www.microsoft.com/en-us/microsoft-365/windows/end-of-ie-support). IMO we could remove this polyfill without a need of a major release since people only need support for IE11 (but I might be wrong). What do you think?


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
