### PR TITLE
Remove setImmediate polyfill

### DIFF
--- a/libs/fetcher.client.js
+++ b/libs/fetcher.client.js
@@ -201,10 +201,9 @@ Request.prototype.end = function (callback) {
             }
         );
     } else {
-        var promise = new Promise(function requestExecutor(resolve, reject) {
-            setImmediate(executeRequest, self, resolve, reject);
-        });
-        promise = promise.then(
+        return new Promise(function requestExecutor(resolve, reject) {
+            return executeRequest(self, resolve, reject);
+        }).then(
             function requestSucceeded(result) {
                 self._captureMetaAndStats(null, result);
                 return result;
@@ -214,7 +213,6 @@ Request.prototype.end = function (callback) {
                 throw err;
             }
         );
-        return promise;
     }
 };
 

--- a/libs/fetcher.client.js
+++ b/libs/fetcher.client.js
@@ -9,7 +9,6 @@
  * Fetcher is a CRUD interface for your data.
  * @module Fetcher
  */
-require('setimmediate');
 var REST = require('./util/http.client');
 var deepmerge = require('deepmerge');
 var DEFAULT_GUID = 'g0';
@@ -188,16 +187,19 @@ Request.prototype.end = function (callback) {
             self,
             function requestSucceeded(result) {
                 self._captureMetaAndStats(null, result);
-                setImmediate(
-                    callback,
-                    null,
-                    result && result.data,
-                    result && result.meta
-                );
+                setTimeout(function () {
+                    callback(
+                        null,
+                        result && result.data,
+                        result && result.meta
+                    );
+                });
             },
             function requestFailed(err) {
                 self._captureMetaAndStats(err);
-                setImmediate(callback, err);
+                setTimeout(function () {
+                    callback(err);
+                });
             }
         );
     } else {

--- a/libs/fetcher.js
+++ b/libs/fetcher.js
@@ -2,7 +2,6 @@
  * Copyright 2014, Yahoo! Inc.
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
-require('setimmediate');
 var OP_READ = 'read';
 var OP_CREATE = 'create';
 var OP_UPDATE = 'update';

--- a/package-lock.json
+++ b/package-lock.json
@@ -2570,11 +2570,6 @@
         "send": "0.17.1"
       }
     },
-    "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
-    },
     "setprototypeof": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "es6-promise": "^4.2.8",
     "fumble": "^0.1.0",
     "object-assign": "^4.0.1",
-    "setimmediate": "^1.0.5",
     "xhr": "^2.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
In the server part, I just removed the import since node already has setImmediate since version 0.9.1.

In the client part, I completely remove it in the promise branch and replaced it with setTimeout in the client branch.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
