### PR TITLE
http: remove unused put and delete methods

### DIFF
--- a/libs/util/http.client.js
+++ b/libs/util/http.client.js
@@ -27,9 +27,7 @@ var DEFAULT_CONFIG = {
     CONTENT_TYPE = 'Content-Type',
     TYPE_JSON = 'application/json',
     METHOD_GET = 'GET',
-    METHOD_PUT = 'PUT',
     METHOD_POST = 'POST',
-    METHOD_DELETE = 'DELETE',
     NULL = null;
 
 var INITIAL_ATTEMPT = 0;
@@ -39,7 +37,7 @@ function normalizeHeaders(headers, method, isCors) {
     if (!isCors) {
         normalized['X-Requested-With'] = 'XMLHttpRequest';
     }
-    var needContentType = method === METHOD_PUT || method === METHOD_POST;
+    var needContentType = method === METHOD_POST;
     forEach(headers, function (v, field) {
         if (field.toLowerCase() === 'content-type') {
             if (needContentType) {
@@ -72,11 +70,7 @@ function shouldRetry(method, config, statusCode, attempt) {
         return false;
     }
 
-    var isIdempotent =
-        method === METHOD_GET ||
-        method === METHOD_PUT ||
-        method === METHOD_DELETE;
-    if (!isIdempotent && !config.unsafeAllowRetry) {
+    if (method === METHOD_POST && !config.unsafeAllowRetry) {
         return false;
     }
 
@@ -269,31 +263,6 @@ module.exports = {
     },
 
     /**
-     * @method put
-     * @param {String} url
-     * @param {Object} headers
-     * @param {Mixed}  data
-     * @param {Object} config  The config object. No retries for PUT.
-     * @param {Number} [config.timeout=3000] Timeout (in ms) for each request
-     * @param {Number} [config.retry.interval=200] The start interval unit (in ms).
-     * @param {Number} [config.retry.maxRetries=0] Number of max retries.
-     * @param {Number} [config.retry.statusCodes=[0, 408, 999]] Response status codes to be retried.
-     * @param {Boolean} [config.cors] Whether to enable CORS & use XDR on IE8/9.
-     * @param {Function} callback The callback function, with two params (error, response)
-     */
-    put: function (url, headers, data, config, callback) {
-        return doXhr(
-            METHOD_PUT,
-            url,
-            headers,
-            data,
-            config,
-            INITIAL_ATTEMPT,
-            callback
-        );
-    },
-
-    /**
      * @method post
      * @param {String} url
      * @param {Object} headers
@@ -313,30 +282,6 @@ module.exports = {
             url,
             headers,
             data,
-            config,
-            INITIAL_ATTEMPT,
-            callback
-        );
-    },
-
-    /**
-     * @method delete
-     * @param {String} url
-     * @param {Object} headers
-     * @param {Object} config  The config object. No retries for DELETE.
-     * @param {Number} [config.timeout=3000] Timeout (in ms) for each request
-     * @param {Number} [config.retry.interval=200] The start interval unit (in ms).
-     * @param {Number} [config.retry.maxRetries=0] Number of max retries.
-     * @param {Number} [config.retry.statusCodes=[0, 408, 999]] Response status codes to be retried.
-     * @param {Boolean} [config.cors] Whether to enable CORS & use XDR on IE8/9.
-     * @param {Function} callback The callback function, with two params (error, response)
-     */
-    delete: function (url, headers, config, callback) {
-        return doXhr(
-            METHOD_DELETE,
-            url,
-            headers,
-            NULL,
             config,
             INITIAL_ATTEMPT,
             callback

--- a/tests/unit/libs/util/http.client.js
+++ b/tests/unit/libs/util/http.client.js
@@ -63,27 +63,6 @@ describe('Client HTTP', function () {
             });
         });
 
-        it('PUT', function (done) {
-            http.put(
-                '/url',
-                { 'X-Foo': 'foo' },
-                { data: 'data' },
-                {},
-                function () {
-                    expect(xhrOptions.length).to.equal(1);
-                    var options = xhrOptions[0];
-                    expect(options.url).to.equal('/url');
-                    expect(options.headers['X-Requested-With']).to.equal(
-                        'XMLHttpRequest'
-                    );
-                    expect(options.headers['X-Foo']).to.equal('foo');
-                    expect(options.method).to.equal('PUT');
-                    expect(options.body).to.eql('{"data":"data"}');
-                    done();
-                }
-            );
-        });
-
         it('POST', function (done) {
             http.post(
                 '/url',
@@ -103,20 +82,6 @@ describe('Client HTTP', function () {
                     done();
                 }
             );
-        });
-
-        it('DELETE', function (done) {
-            http['delete']('/url', { 'X-Foo': 'foo' }, {}, function () {
-                expect(xhrOptions.length).to.equal(1);
-                var options = xhrOptions[0];
-                expect(options.url).to.equal('/url');
-                expect(options.headers['X-Requested-With']).to.equal(
-                    'XMLHttpRequest'
-                );
-                expect(options.headers['X-Foo']).to.equal('foo');
-                expect(options.method).to.equal('DELETE');
-                done();
-            });
         });
     });
 
@@ -152,27 +117,6 @@ describe('Client HTTP', function () {
             );
         });
 
-        it('PUT', function (done) {
-            http.put(
-                '/url',
-                { 'X-Foo': 'foo' },
-                { data: 'data' },
-                { cors: true },
-                function () {
-                    expect(xhrOptions.length).to.equal(1);
-                    var options = xhrOptions[0];
-                    expect(options.url).to.equal('/url');
-                    expect(options.headers).to.not.have.property(
-                        'X-Requested-With'
-                    );
-                    expect(options.headers['X-Foo']).to.equal('foo');
-                    expect(options.method).to.equal('PUT');
-                    expect(options.body).to.eql('{"data":"data"}');
-                    done();
-                }
-            );
-        });
-
         it('POST', function (done) {
             http.post(
                 '/url',
@@ -189,25 +133,6 @@ describe('Client HTTP', function () {
                     expect(options.headers['X-Foo']).to.equal('foo');
                     expect(options.method).to.equal('POST');
                     expect(options.body).to.eql('{"data":"data"}');
-                    done();
-                }
-            );
-        });
-
-        it('DELETE', function (done) {
-            http['delete'](
-                '/url',
-                { 'X-Foo': 'foo' },
-                { cors: true },
-                function () {
-                    expect(xhrOptions.length).to.equal(1);
-                    var options = xhrOptions[0];
-                    expect(options.url).to.equal('/url');
-                    expect(options.headers).to.not.have.property(
-                        'X-Requested-With'
-                    );
-                    expect(options.headers['X-Foo']).to.equal('foo');
-                    expect(options.method).to.equal('DELETE');
                     done();
                 }
             );
@@ -385,20 +310,6 @@ describe('Client HTTP', function () {
                 });
             });
 
-            it('should use xhrTimeout for PUT', function (done) {
-                http.put(
-                    '/url',
-                    { 'X-Foo': 'foo' },
-                    { data: 'data' },
-                    config,
-                    function () {
-                        var options = xhrOptions[0];
-                        expect(options.timeout).to.equal(3000);
-                        done();
-                    }
-                );
-            });
-
             it('should use xhrTimeout for POST', function (done) {
                 http.post(
                     '/url',
@@ -411,14 +322,6 @@ describe('Client HTTP', function () {
                         done();
                     }
                 );
-            });
-
-            it('should use xhrTimeout for DELETE', function (done) {
-                http['delete']('/url', { 'X-Foo': 'foo' }, config, function () {
-                    var options = xhrOptions[0];
-                    expect(options.timeout).to.equal(3000);
-                    done();
-                });
             });
         });
 
@@ -435,20 +338,6 @@ describe('Client HTTP', function () {
                 });
             });
 
-            it('should override default xhrTimeout for PUT', function (done) {
-                http.put(
-                    '/url',
-                    { 'X-Foo': 'foo' },
-                    { data: 'data' },
-                    config,
-                    function () {
-                        var options = xhrOptions[0];
-                        expect(options.timeout).to.equal(6000);
-                        done();
-                    }
-                );
-            });
-
             it('should override default xhrTimeout for POST', function (done) {
                 http.post(
                     '/url',
@@ -461,14 +350,6 @@ describe('Client HTTP', function () {
                         done();
                     }
                 );
-            });
-
-            it('should override default xhrTimeout for DELETE', function (done) {
-                http['delete']('/url', { 'X-Foo': 'foo' }, config, function () {
-                    var options = xhrOptions[0];
-                    expect(options.timeout).to.equal(6000);
-                    done();
-                });
             });
         });
     });


### PR DESCRIPTION
@redonkulus while refactoring the tests for the other PR, I realized that we don't use `delete` nor `put` from the http module.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
