### PR TITLE
package.json: remove unnecessary object-assign dependency

### DIFF
--- a/libs/fetcher.js
+++ b/libs/fetcher.js
@@ -9,7 +9,6 @@ var OP_DELETE = 'delete';
 var GET = 'GET';
 var qs = require('querystring');
 var fumble = require('fumble');
-var objectAssign = require('object-assign');
 var RESOURCE_SANTIZER_REGEXP = /[^\w.]+/g;
 
 function parseValue(value) {
@@ -708,7 +707,7 @@ Fetcher.prototype['delete'] = function (resource, params, config, callback) {
  * @param {string} [options.xhrPath="/api"] The path for XHR requests. Will be ignored server side.
  */
 Fetcher.prototype.updateOptions = function (options) {
-    this.options = objectAssign(this.options, options);
+    this.options = Object.assign(this.options, options);
     this.req = this.options.req || {};
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2102,11 +2102,6 @@
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
     },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
     "object-inspect": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "deepmerge": "^4.2.2",
     "fumble": "^0.1.0",
-    "object-assign": "^4.0.1",
     "xhr": "^2.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
We were only using object-assign on server so we can safely replace it
with the native implementation.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
