### PR TITLE
Replace xhr with native fetch

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,6 @@ module.exports = {
     rules: {
         'no-prototype-builtins': 0,
         'no-unexpected-multiline': 0,
-        'dot-notation': [2, { allowKeywords: false }],
     },
     globals: {
         Promise: 'readonly',

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Universal data access layer for web applications.
 
-Typically on the server, you call your API or database directly to fetch some data. However, on the client, you cannot always call your services in the same way (i.e, cross domain policies). Instead, XHR requests need to be made to the server which get forwarded to your service.
+Typically on the server, you call your API or database directly to fetch some data. However, on the client, you cannot always call your services in the same way (i.e, cross domain policies). Instead, XHR/fetch requests need to be made to the server which get forwarded to your service.
 
 Having to write code differently for both environments is duplicative and error prone. Fetchr provides an abstraction layer over your data service calls so that you can fetch data using the same API on the server and client side.
 
@@ -149,8 +149,8 @@ See the [simple example](https://github.com/yahoo/fetchr/tree/master/examples/si
 
 ## Service Metadata
 
-Service calls on the client transparently become xhr requests.
-It is a good idea to set cache headers on common xhr calls.
+Service calls on the client transparently become fetch requests.
+It is a good idea to set cache headers on common fetch calls.
 You can do so by providing a third parameter in your service's callback.
 If you want to look at what headers were set by the service you just called,
 simply inspect the third parameter in the callback.
@@ -169,7 +169,7 @@ export default {
             headers: {
                 'cache-control': 'public, max-age=3600',
             },
-            statusCode: 200, // You can even provide a custom statusCode for the xhr response
+            statusCode: 200, // You can even provide a custom statusCode for the fetch response
         };
         callback(null, data, meta);
     },
@@ -241,9 +241,9 @@ fetcher
     });
 ```
 
-## XHR Object
+## Abort support
 
-The xhr object is returned by the `.end()` method as long as you're _not_ chaining promises.
+An object with an `abort` method is returned by the `.end()` method as long as you're _not_ chaining promises.
 This is useful if you want to abort a request before it is completed.
 
 ```js
@@ -253,11 +253,11 @@ const req = fetcher
     .end(function (err, data, meta) {
         // err.output will be { message: "Not found", more: "meta data" }
     });
-// req is the xhr object
+
 req.abort();
 ```
 
-However, you can't acces the xhr object if using promise chaining like so:
+However, due to the current implementation, you can't access this method if using promise chaining like so:
 
 ```js
 const req = fetcher
@@ -268,10 +268,10 @@ const req = fetcher
 req.then(onResolve, onReject);
 ```
 
-## XHR Timeouts
+## Timeouts
 
 `xhrTimeout` is an optional config property that allows you to set timeout (in ms) for all clientside requests, defaults to `3000`.
-On the clientside, xhrPath and xhrTimeout will be used for XHR requests.
+On the clientside, xhrPath and xhrTimeout will be used for all requests.
 On the serverside, xhrPath and xhrTimeout are not needed and are ignored.
 
 ```js
@@ -294,9 +294,9 @@ fetcher
     });
 ```
 
-## XHR Params Processing
+## Params Processing
 
-For some applications, there may be a situation where you need to process the service params passed in XHR request before params are sent to the actual service. Typically, you would process these params in the service itself. However, if you want to perform processing across many services (i.e. sanitization for security), then you can use the `paramsProcessor` option.
+For some applications, there may be a situation where you need to process the service params passed in the request before they are sent to the actual service. Typically, you would process them in the service itself. However, if you neet to perform processing across many services (i.e. sanitization for security), then you can use the `paramsProcessor` option.
 
 `paramsProcessor` is a function that is passed into the `Fetcher.middleware` method. It is passed three arguments, the request object, the serviceInfo object, and the service params object. The `paramsProcessor` function can then modify the service params if needed.
 
@@ -318,9 +318,9 @@ app.use(
 );
 ```
 
-## XHR Response Formatting
+## Response Formatting
 
-For some applications, there may be a situation where you need to modify an XHR response before it is passed to the client. Typically, you would apply your modifications in the service itself. However, if you want to modify the XHR responses across many services (i.e. add debug information), then you can use the `responseFormatter` option.
+For some applications, there may be a situation where you need to modify the response before it is passed to the client. Typically, you would apply your modifications in the service itself. However, if you need to modify the responses across many services (i.e. add debug information), then you can use the `responseFormatter` option.
 
 `responseFormatter` is a function that is passed into the `Fetcher.middleware` method. It is passed three arguments, the request object, response object and the service response object (i.e. the data returned from your service). The `responseFormatter` function can then modify the service response to add additional information.
 
@@ -342,7 +342,7 @@ app.use(
 );
 ```
 
-Now when an XHR request is performed, your response will contain the `debug` property added above.
+Now when an request is performed, your response will contain the `debug` property added above.
 
 ## CORS Support
 
@@ -392,31 +392,31 @@ fetcher
 
 ## CSRF Protection
 
-You can protect your XHR paths from CSRF attacks by adding a middleware in front of the fetchr middleware:
+You can protect your Fetchr middleware paths from CSRF attacks by adding a middleware in front of it:
 
 `app.use('/myCustomAPIEndpoint', csrf(), Fetcher.middleware());`
 
 You could use https://github.com/expressjs/csurf for this as an example.
 
-Next you need to make sure that the CSRF token is being sent with our XHR requests so that they can be validated. To do this, pass the token in as a key in the `options.context` object on the client:
+Next you need to make sure that the CSRF token is being sent with our requests so that they can be validated. To do this, pass the token in as a key in the `options.context` object on the client:
 
 ```js
 const fetcher = new Fetcher({
-    xhrPath: '/myCustomAPIEndpoint', //xhrPath is REQUIRED on the clientside fetcher instantiation
+    xhrPath: '/myCustomAPIEndpoint', // xhrPath is REQUIRED on the clientside fetcher instantiation
     context: {
-        // These context values are persisted with XHR calls as query params
+        // These context values are persisted with client calls as query params
         _csrf: 'Ax89D94j',
     },
 });
 ```
 
-This `_csrf` will be sent in all XHR requests as a query parameter so that it can be validated on the server.
+This `_csrf` will be sent in all client requests as a query parameter so that it can be validated on the server.
 
 ## Service Call Config
 
 When calling a Fetcher service you can pass an optional config object.
 
-When this call is made from the client, the config object is used to define XHR request options and can be used to override default options:
+When this call is made from the client, the config object is used to set some request options and can be used to override default options:
 
 ```js
 //app.js - client
@@ -445,7 +445,7 @@ fetcher
     .end();
 ```
 
-With this configuration, Fetchr will retry all requests that fail with 408 status code or with an XHR 0 status code two more times before returning an error. The interval between each request respects
+With this configuration, Fetchr will retry all requests that fail with 408 status code or that failed without even reaching the service (status code 0 means, for example, that the client was not able to reach the server) two more times before returning an error. The interval between each request respects
 the following formula, based on the exponential backoff and full jitter strategy published in [this AWS architecture blog post](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/):
 
 ```js
@@ -487,14 +487,14 @@ fetcher
 
 ## Context Variables
 
-By Default, fetchr appends all context values to the xhr url as query params. `contextPicker` allows you to greater control over which context variables get sent as query params depending on the xhr method (`GET` or `POST`). This is useful when you want to limit the number of variables in a `GET` url in order not to accidentally [cache bust](http://webassets.readthedocs.org/en/latest/expiring.html).
+By Default, fetchr appends all context values to the request url as query params. `contextPicker` allows you to have greater control over which context variables get sent as query params depending on the request method (`GET` or `POST`). This is useful when you want to limit the number of variables in a `GET` url in order not to accidentally [cache bust](http://webassets.readthedocs.org/en/latest/expiring.html).
 
 `contextPicker` follows the same format as the `predicate` parameter in [`lodash/pickBy`](https://lodash.com/docs#pickBy) with two arguments: `(value, key)`.
 
 ```js
 const fetcher = new Fetcher({
     context: {
-        // These context values are persisted with XHR calls as query params
+        // These context values are persisted with client calls as query params
         _csrf: 'Ax89D94j',
         device: 'desktop',
     },
@@ -512,7 +512,7 @@ const fetcher = new Fetcher({
 
 const fetcher = new Fetcher({
     context: {
-        // These context values are persisted with XHR calls as query params
+        // These context values are persisted with client calls as query params
         _csrf: 'Ax89D94j',
         device: 'desktop',
     },

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Having to write code differently for both environments is duplicative and error 
 npm install fetchr --save
 ```
 
+_Important:_ when on browser, `Fetchr` relies fully on [`Fetch`](https://fetch.spec.whatwg.org/) API. If you need to support old browsers, you will need to install a polyfill as well (eg. https://github.com/github/fetch).
+
 ## Setup
 
 Follow the steps below to setup Fetchr properly. This assumes you are using the [Express](https://www.npmjs.com/package/express) framework.

--- a/docs/fetchr.md
+++ b/docs/fetchr.md
@@ -6,8 +6,8 @@ Creates a new fetchr plugin instance with the following parameters:
 
 -   `options`: An object containing the plugin settings
 -   `options.req` (required on server): The request object. It can contain per-request/context data.
--   `options.xhrPath` (optional): The path for XHR requests. Will be ignored serverside.
--   `options.xhrTimeout` (optional): Timeout in milliseconds for all XHR requests
+-   `options.xhrPath` (optional): The path for all requests. Will be ignored serverside.
+-   `options.xhrTimeout` (optional): Timeout in milliseconds for all requests
 -   `options.corsPath` (optional): Base CORS path in case CORS is enabled
 -   `options.context` (optional): The context object
 -   `options.contextPicker` (optional): The context predicate functions, it will be applied to lodash/object/pick to pick values from context object

--- a/libs/fetcher.client.js
+++ b/libs/fetcher.client.js
@@ -11,8 +11,8 @@
  */
 var REST = require('./util/http.client');
 var DEFAULT_GUID = 'g0';
-var DEFAULT_XHR_PATH = '/api';
-var DEFAULT_XHR_TIMEOUT = 3000;
+var DEFAULT_PATH = '/api';
+var DEFAULT_TIMEOUT = 3000;
 var MAX_URI_LEN = 2048;
 var OP_READ = 'read';
 var defaultConstructGetUri = require('./util/defaultConstructGetUri');
@@ -91,8 +91,8 @@ function Request(operation, resource, options) {
     this.resource = resource;
     this.options = {
         headers: options.headers,
-        xhrPath: options.xhrPath || DEFAULT_XHR_PATH,
-        xhrTimeout: options.xhrTimeout || DEFAULT_XHR_TIMEOUT,
+        xhrPath: options.xhrPath || DEFAULT_PATH,
+        xhrTimeout: options.xhrTimeout || DEFAULT_TIMEOUT,
         corsPath: options.corsPath,
         context: options.context || {},
         contextPicker: options.contextPicker || {},
@@ -374,8 +374,8 @@ Request.prototype._constructGroupUri = function (uri) {
  * Fetcher class for the client. Provides CRUD methods.
  * @class FetcherClient
  * @param {Object} options configuration options for Fetcher
- * @param {String} [options.xhrPath="/api"] The path for XHR requests
- * @param {Number} [options.xhrTimout=3000] Timeout in milliseconds for all XHR requests
+ * @param {String} [options.xhrPath="/api"] The path for requests
+ * @param {Number} [options.xhrTimout=3000] Timeout in milliseconds for all requests
  * @param {Boolean} [options.corsPath] Base CORS path in case CORS is enabled
  * @param {Object} [options.context] The context object that is propagated to all outgoing
  *      requests as query params.  It can contain current-session/context data that should
@@ -550,7 +550,7 @@ Fetcher.prototype = {
 
     /**
      * get the serviceMeta array.
-     * The array contains all xhr meta returned in this session
+     * The array contains all requests meta returned in this session
      * with the 0 index being the first call.
      * @method getServiceMeta
      * @return {Array} array of metadata returned by each service call

--- a/libs/util/defaultConstructGetUri.js
+++ b/libs/util/defaultConstructGetUri.js
@@ -19,7 +19,7 @@ function jsonifyComplexType(value) {
 }
 
 /**
- * Construct xhr GET URI.
+ * Construct GET URI.
  * @method defaultConstructGetUri
  * @param {String} uri base URI
  * @param {String} resource Resource name

--- a/libs/util/http.client.js
+++ b/libs/util/http.client.js
@@ -126,7 +126,7 @@ function mergeConfig(config) {
     return cfg;
 }
 
-function doXhr(method, url, headers, data, config, attempt, callback) {
+function doRequest(method, url, headers, data, config, attempt, callback) {
     headers = normalizeHeaders(headers, method, config.cors);
     config = mergeConfig(config);
 
@@ -149,8 +149,8 @@ function doXhr(method, url, headers, data, config, attempt, callback) {
                         config.retry.interval *
                         Math.pow(2, attempt);
 
-                    setTimeout(function retryXHR() {
-                        doXhr(
+                    setTimeout(function retryRequest() {
+                        doRequest(
                             method,
                             url,
                             headers,
@@ -284,7 +284,7 @@ module.exports = {
      * @param {Function} callback The callback function, with two params (error, response)
      */
     get: function (url, headers, config, callback) {
-        return doXhr(
+        return doRequest(
             METHOD_GET,
             url,
             headers,
@@ -310,7 +310,7 @@ module.exports = {
      * @param {Function} callback The callback function, with two params (error, response)
      */
     post: function (url, headers, data, config, callback) {
-        return doXhr(
+        return doRequest(
             METHOD_POST,
             url,
             headers,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "chai": "^4.2.0",
         "eslint": "^7.29.0",
         "express": "^4.17.1",
+        "fetch-mock": "^9.11.0",
         "mocha": "^9.0.0",
         "mockery": "^2.0.0",
         "node-fetch": "^2.6.2",
@@ -395,6 +396,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
+      "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
+      "dev": true,
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1617,6 +1630,17 @@
       "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
       "dev": true
     },
+    "node_modules/core-js": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.18.0.tgz",
+      "integrity": "sha512-WJeQqq6jOYgVgg4NrXKL0KLQhi0CT4ZOCvFL+3CQ5o7I6J8HkT5wd53EadMfqTDp1so/MT1J+w2ujhWcCJtN7w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -2318,6 +2342,71 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fetch-mock": {
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.11.0.tgz",
+      "integrity": "sha512-PG1XUv+x7iag5p/iNHD4/jdpxL9FtVSqRMUQhPab4hVDt80T1MH5ehzVrL2IdXO9Q2iBggArFvPqjUbHFuI58Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.0.0",
+        "@babel/runtime": "^7.0.0",
+        "core-js": "^3.0.0",
+        "debug": "^4.1.1",
+        "glob-to-regexp": "^0.4.0",
+        "is-subset": "^0.1.1",
+        "lodash.isequal": "^4.5.0",
+        "path-to-regexp": "^2.2.1",
+        "querystring": "^0.2.0",
+        "whatwg-url": "^6.5.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "funding": {
+        "type": "charity",
+        "url": "https://www.justgiving.com/refugee-support-europe"
+      },
+      "peerDependencies": {
+        "node-fetch": "*"
+      },
+      "peerDependenciesMeta": {
+        "node-fetch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fetch-mock/node_modules/path-to-regexp": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+      "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
+      "dev": true
+    },
+    "node_modules/fetch-mock/node_modules/tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/fetch-mock/node_modules/webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
+    },
+    "node_modules/fetch-mock/node_modules/whatwg-url": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+      "dev": true,
+      "dependencies": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -3001,6 +3090,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-subset": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
+      "dev": true
+    },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -3344,10 +3439,22 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+      "dev": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
     "node_modules/lodash.truncate": {
@@ -4375,6 +4482,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/querystring": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
+      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -4433,6 +4550,12 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "dev": true
     },
     "node_modules/regexpp": {
       "version": "3.2.0",
@@ -5996,6 +6119,15 @@
       "integrity": "sha512-rycZXvQ+xS9QyIcJ9HXeDWf1uxqlbVFAUq0Rq0dbc50Zb/+wUe/ehyfzGfm9KZZF0kBejYgxltBXocP+gKdL2g==",
       "dev": true
     },
+    "@babel/runtime": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
+      "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@babel/template": {
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
@@ -7017,6 +7149,12 @@
       "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
       "dev": true
     },
+    "core-js": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.18.0.tgz",
+      "integrity": "sha512-WJeQqq6jOYgVgg4NrXKL0KLQhi0CT4ZOCvFL+3CQ5o7I6J8HkT5wd53EadMfqTDp1so/MT1J+w2ujhWcCJtN7w==",
+      "dev": true
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -7574,6 +7712,58 @@
         "pend": "~1.2.0"
       }
     },
+    "fetch-mock": {
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.11.0.tgz",
+      "integrity": "sha512-PG1XUv+x7iag5p/iNHD4/jdpxL9FtVSqRMUQhPab4hVDt80T1MH5ehzVrL2IdXO9Q2iBggArFvPqjUbHFuI58Q==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.0.0",
+        "@babel/runtime": "^7.0.0",
+        "core-js": "^3.0.0",
+        "debug": "^4.1.1",
+        "glob-to-regexp": "^0.4.0",
+        "is-subset": "^0.1.1",
+        "lodash.isequal": "^4.5.0",
+        "path-to-regexp": "^2.2.1",
+        "querystring": "^0.2.0",
+        "whatwg-url": "^6.5.0"
+      },
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+          "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
+          "dev": true
+        },
+        "tr46": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+          "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+          "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        }
+      }
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -8063,6 +8253,12 @@
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true
     },
+    "is-subset": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
+      "dev": true
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -8330,10 +8526,22 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+      "dev": true
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
     "lodash.truncate": {
@@ -9125,6 +9333,12 @@
         "side-channel": "^1.0.4"
       }
     },
+    "querystring": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
+      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
+      "dev": true
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -9171,6 +9385,12 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "dev": true
     },
     "regexpp": {
       "version": "3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,7 @@
     "": {
       "version": "0.6.2",
       "dependencies": {
-        "fumble": "^0.1.0",
-        "xhr": "^2.4.0"
+        "fumble": "^0.1.0"
       },
       "devDependencies": {
         "abortcontroller-polyfill": "^1.7.3",
@@ -1775,11 +1774,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/dom-walk": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
-      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
-    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -2788,15 +2782,6 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true
     },
-    "node_modules/global": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
-      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
-      "dependencies": {
-        "min-document": "^2.19.0",
-        "process": "^0.11.10"
-      }
-    },
     "node_modules/globals": {
       "version": "13.10.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.10.0.tgz",
@@ -3049,11 +3034,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/is-function": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
-      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
     },
     "node_modules/is-glob": {
       "version": "4.0.1",
@@ -3581,14 +3561,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "dependencies": {
-        "dom-walk": "^0.1.0"
       }
     },
     "node_modules/minimatch": {
@@ -4179,11 +4151,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/parse-headers": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.3.tgz",
-      "integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA=="
-    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -4351,14 +4318,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "engines": {
-        "node": ">= 0.6.0"
       }
     },
     "node_modules/process-nextick-args": {
@@ -5682,25 +5641,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/xhr": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
-      "integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
-      "dependencies": {
-        "global": "~4.4.0",
-        "is-function": "^1.0.1",
-        "parse-headers": "^2.0.0",
-        "xtend": "^4.0.0"
-      }
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "engines": {
-        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {
@@ -7263,11 +7203,6 @@
         "esutils": "^2.0.2"
       }
     },
-    "dom-walk": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
-      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
-    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -8050,15 +7985,6 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true
     },
-    "global": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
-      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
-      "requires": {
-        "min-document": "^2.19.0",
-        "process": "^0.11.10"
-      }
-    },
     "globals": {
       "version": "13.10.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.10.0.tgz",
@@ -8233,11 +8159,6 @@
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
-    },
-    "is-function": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
-      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
     },
     "is-glob": {
       "version": "4.0.1",
@@ -8643,14 +8564,6 @@
       "dev": true,
       "requires": {
         "mime-db": "1.44.0"
-      }
-    },
-    "min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "requires": {
-        "dom-walk": "^0.1.0"
       }
     },
     "minimatch": {
@@ -9110,11 +9023,6 @@
         "callsites": "^3.0.0"
       }
     },
-    "parse-headers": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.3.tgz",
-      "integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA=="
-    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -9238,11 +9146,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
       "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
       "dev": true
-    },
-    "process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -10269,22 +10172,6 @@
       "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
       "dev": true,
       "requires": {}
-    },
-    "xhr": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
-      "integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
-      "requires": {
-        "global": "~4.4.0",
-        "is-function": "^1.0.1",
-        "parse-headers": "^2.0.0",
-        "xtend": "^4.0.0"
-      }
-    },
-    "xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "xhr": "^2.4.0"
       },
       "devDependencies": {
+        "abortcontroller-polyfill": "^1.7.3",
         "chai": "^4.2.0",
         "eslint": "^7.29.0",
         "express": "^4.17.1",
@@ -877,6 +878,12 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "dev": true
+    },
+    "node_modules/abortcontroller-polyfill": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.3.tgz",
+      "integrity": "sha512-zetDJxd89y3X99Kvo4qFx8GKlt6GsvN3UcRZHwU6iFA/0KiOmhkTVhe8oRoTBiTVPZu09x3vCra47+w8Yz1+2Q==",
       "dev": true
     },
     "node_modules/accepts": {
@@ -6551,6 +6558,12 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "dev": true
+    },
+    "abortcontroller-polyfill": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.3.tgz",
+      "integrity": "sha512-zetDJxd89y3X99Kvo4qFx8GKlt6GsvN3UcRZHwU6iFA/0KiOmhkTVhe8oRoTBiTVPZu09x3vCra47+w8Yz1+2Q==",
       "dev": true
     },
     "accepts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "express": "^4.17.1",
         "mocha": "^9.0.0",
         "mockery": "^2.0.0",
+        "node-fetch": "^2.6.2",
         "nyc": "^15.1.0",
         "pre-commit": "^1.0.0",
         "prettier": "^2.3.2",
@@ -3688,10 +3689,13 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.4.tgz",
+      "integrity": "sha512-aD1fO+xtLiSCc9vuD+sYMxpIuQyhHscGSkBEo2o5LTV/3bTEAYvdUii29n8LlO5uLCmWdGP7uVUVXFo5SRdkLA==",
       "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
       "engines": {
         "node": "4.x || >=6.0.0"
       }
@@ -4336,6 +4340,15 @@
       },
       "engines": {
         "node": ">=10.18.1"
+      }
+    },
+    "node_modules/puppeteer/node_modules/node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true,
+      "engines": {
+        "node": "4.x || >=6.0.0"
       }
     },
     "node_modules/puppeteer/node_modules/progress": {
@@ -5176,6 +5189,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -5306,6 +5325,12 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "dev": true
+    },
     "node_modules/webpack": {
       "version": "5.54.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.54.0.tgz",
@@ -5385,6 +5410,16 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/which": {
       "version": "1.3.1",
@@ -8566,10 +8601,13 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "dev": true
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.4.tgz",
+      "integrity": "sha512-aD1fO+xtLiSCc9vuD+sYMxpIuQyhHscGSkBEo2o5LTV/3bTEAYvdUii29n8LlO5uLCmWdGP7uVUVXFo5SRdkLA==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
     },
     "node-preload": {
       "version": "0.2.1",
@@ -9064,6 +9102,12 @@
         "ws": "7.4.6"
       },
       "dependencies": {
+        "node-fetch": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+          "dev": true
+        },
         "progress": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
@@ -9714,6 +9758,12 @@
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
       "dev": true
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
+    },
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -9816,6 +9866,12 @@
         "graceful-fs": "^4.1.2"
       }
     },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "dev": true
+    },
     "webpack": {
       "version": "5.54.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.54.0.tgz",
@@ -9873,6 +9929,16 @@
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.0.tgz",
       "integrity": "sha512-fahN08Et7P9trej8xz/Z7eRu8ltyiygEo/hnRi9KqBUs80KeDcnf96ZJo++ewWd84fEf3xSX9bp4ZS9hbw0OBw==",
       "dev": true
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dev": true,
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "express": "^4.17.1",
     "mocha": "^9.0.0",
     "mockery": "^2.0.0",
+    "node-fetch": "^2.6.2",
     "nyc": "^15.1.0",
     "pre-commit": "^1.0.0",
     "prettier": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "xhr": "^2.4.0"
   },
   "devDependencies": {
+    "abortcontroller-polyfill": "^1.7.3",
     "chai": "^4.2.0",
     "eslint": "^7.29.0",
     "express": "^4.17.1",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "format:check": "prettier --check .",
     "lint": "eslint . && npm run format:check",
     "test": "npm run test:unit && npm run test:functional",
-    "test:coverage":  "nyc --reporter=lcov npm run test:unit",
-    "test:unit": "NODE_ENV=test mocha tests/unit/ --recursive --reporter spec --timeout 20000 --exit",
+    "test:coverage": "nyc --reporter=lcov npm run test:unit",
+    "test:unit": "NODE_ENV=test mocha tests/unit/ --recursive --reporter spec --timeout 20000 --exit --require tests/unit/setup.js",
     "test:functional": "NODE_ENV=test mocha tests/functional/*.test.js --reporter spec --exit"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "chai": "^4.2.0",
     "eslint": "^7.29.0",
     "express": "^4.17.1",
+    "fetch-mock": "^9.11.0",
     "mocha": "^9.0.0",
     "mockery": "^2.0.0",
     "node-fetch": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     }
   ],
   "dependencies": {
-    "fumble": "^0.1.0",
-    "xhr": "^2.4.0"
+    "fumble": "^0.1.0"
   },
   "devDependencies": {
     "abortcontroller-polyfill": "^1.7.3",

--- a/tests/functional/fetchr.test.js
+++ b/tests/functional/fetchr.test.js
@@ -163,13 +163,13 @@ describe('client/server integration', () => {
                 meta: { foo: 'bar' },
                 output: { message: 'error' },
                 rawRequest: {
-                    url: '/api/error?returnMeta=true',
+                    url: 'http://localhost:3000/api/error?returnMeta=true',
                     method: 'GET',
                     headers: { 'X-Requested-With': 'XMLHttpRequest' },
                 },
                 statusCode: 400,
                 timeout: 3000,
-                url: '/api/error?returnMeta=true',
+                url: 'http://localhost:3000/api/error?returnMeta=true',
             });
         });
 
@@ -189,13 +189,13 @@ describe('client/server integration', () => {
                 meta: {},
                 output: { message: 'unexpected' },
                 rawRequest: {
-                    url: '/api/error;error=unexpected?returnMeta=true',
+                    url: 'http://localhost:3000/api/error;error=unexpected?returnMeta=true',
                     method: 'GET',
                     headers: { 'X-Requested-With': 'XMLHttpRequest' },
                 },
                 statusCode: 500,
                 timeout: 3000,
-                url: '/api/error;error=unexpected?returnMeta=true',
+                url: 'http://localhost:3000/api/error;error=unexpected?returnMeta=true',
             });
         });
 
@@ -209,11 +209,11 @@ describe('client/server integration', () => {
                 statusCode: 404,
                 body: { error: 'page not found' },
                 rawRequest: {
-                    url: '/non-existent/item?returnMeta=true',
+                    url: 'http://localhost:3000/non-existent/item?returnMeta=true',
                     method: 'GET',
                     headers: { 'X-Requested-With': 'XMLHttpRequest' },
                 },
-                url: '/non-existent/item?returnMeta=true',
+                url: 'http://localhost:3000/non-existent/item?returnMeta=true',
                 timeout: 3000,
             });
         });
@@ -227,14 +227,13 @@ describe('client/server integration', () => {
             });
 
             expect(response).to.deep.equal({
-                code: 'ETIMEDOUT',
                 statusCode: 0,
                 rawRequest: {
-                    url: '/api/error;error=timeout?returnMeta=true',
+                    url: 'http://localhost:3000/api/error;error=timeout?returnMeta=true',
                     method: 'GET',
                     headers: { 'X-Requested-With': 'XMLHttpRequest' },
                 },
-                url: '/api/error;error=timeout?returnMeta=true',
+                url: 'http://localhost:3000/api/error;error=timeout?returnMeta=true',
                 timeout: 20,
             });
         });

--- a/tests/functional/server.js
+++ b/tests/functional/server.js
@@ -1,0 +1,8 @@
+const app = require('./app');
+const buildClient = require('./buildClient');
+
+buildClient().then(() => {
+    app.listen(3000, () => {
+        console.log('http://localhost:3000');
+    });
+});

--- a/tests/mock/mockApp.js
+++ b/tests/mock/mockApp.js
@@ -2,7 +2,7 @@
  * Copyright 2016, Yahoo! Inc.
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
-var DEFAULT_XHR_PATH = '/api';
+var DEFAULT_PATH = '/api';
 
 var express = require('express');
 var app = express();
@@ -16,7 +16,7 @@ FetcherServer.registerService(mockErrorService);
 FetcherServer.registerService(mockNoopService);
 
 app.use(express.json());
-app.use(DEFAULT_XHR_PATH, FetcherServer.middleware());
+app.use(DEFAULT_PATH, FetcherServer.middleware());
 
 module.exports = app;
-module.exports.DEFAULT_XHR_PATH = DEFAULT_XHR_PATH;
+module.exports.DEFAULT_PATH = DEFAULT_PATH;

--- a/tests/unit/libs/util/http.client.js
+++ b/tests/unit/libs/util/http.client.js
@@ -434,7 +434,7 @@ describe('Client HTTP', function () {
         });
     });
 
-    describe('xhr errors', function () {
+    describe('request errors', function () {
         it('should pass-through any xhr error', function (done) {
             responseStatus = 0;
             fetchMock.get('/url', {

--- a/tests/unit/setup.js
+++ b/tests/unit/setup.js
@@ -1,0 +1,23 @@
+// As seen in isomorphic-fetch fetch polyfill:
+// https://github.com/matthew-andrews/isomorphic-fetch/blob/fc5e0d0d0b180e5b4c70b2ae7f738c50a9a51b25/fetch-npm-node.js
+
+'use strict';
+
+const nodeFetch = require('node-fetch');
+const {
+    AbortController,
+    abortableFetch,
+} = require('abortcontroller-polyfill/dist/cjs-ponyfill');
+
+const { fetch, Request } = abortableFetch({
+    fetch: nodeFetch,
+    Request: nodeFetch.Request,
+});
+
+if (!global.fetch) {
+    global.AbortController = AbortController;
+    global.Headers = nodeFetch.Headers;
+    global.Request = Request;
+    global.Response = nodeFetch.Response;
+    global.fetch = fetch;
+}


### PR DESCRIPTION
## What is done
- Completely replaced xhr with fetch
- Removed all xhr names from the docs
- Added note for users that they need to install a polyfill if they need to support old browsers
- The current API is still backward compatible

## What I didn't do (but I will do in future PRs)
- Remove xhr names from the public API (eg. xhrPath, xhrTimeout). I didn't do it right now since it would require users to update their code in order to benefit from this update;
- Fix the retry/abort bug that I mentioned on #278. I fixed it in a local branch but with xhr. Then I realized that I would have to rewrite everything again to make it work with fetch. So I opted to keep the bug for now;
- I didn't cleanup much the code. I tried to keep everything as it was as much as possible. While it was very tempting to refactor everything, I think the PR would get huge and hard to review. But the error handling part requires some love as well the unit tests.

Maybe the github diff is not that helpful here. But as I said, I tried to not change the code much. Mainly, the `io` function from `http.client` module had to be updated. The place that I think is super critical to review is the timeout implementation (so I  recommend you to triple check that).
 
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
