### PR TITLE
Remove support for returnMeta query param

### DIFF
--- a/libs/fetcher.client.js
+++ b/libs/fetcher.client.js
@@ -269,19 +269,7 @@ function executeRequest(request, resolve, reject) {
                 request.options.context
             );
         }
-        // TODO: Remove `returnMeta` feature flag after next release
-        // This feature flag will enable the new return format for GET api requests
-        // Whereas before any data from services was returned as is. We now return
-        // an object with a data key containing the service response, and a meta key
-        // containing the service's metadata response (i.e headers and statusCode).
-        // We need this feature flag to be truly backwards compatible because it is
-        // concievable that some active browser sessions could have the old version of
-        // client fetcher while the server upgrades to the new version. This could be
-        // easily fixed by refreshing the browser, but the feature flag will ensure
-        // old fetcher clients will receive the old format and the new client will
-        // receive the new format
-        get_uri += get_uri.indexOf('?') !== -1 ? '&' : '?';
-        get_uri += 'returnMeta=true';
+
         if (get_uri.length <= MAX_URI_LEN) {
             uri = get_uri;
         } else {

--- a/libs/fetcher.js
+++ b/libs/fetcher.js
@@ -459,31 +459,21 @@ Fetcher.middleware = function (options) {
                     }
                     if (err) {
                         var errResponse = getErrorResponse(err);
-                        if (req.query && req.query.returnMeta) {
-                            res.status(errResponse.statusCode).json(
-                                responseFormatter(req, res, {
-                                    output: errResponse.output,
-                                    meta: meta,
-                                })
-                            );
-                        } else {
-                            res.status(errResponse.statusCode).json(
-                                responseFormatter(req, res, errResponse.output)
-                            );
-                        }
-                        return;
-                    }
-                    if (req.query.returnMeta) {
-                        res.status(meta.statusCode || 200).json(
+                        res.status(errResponse.statusCode).json(
                             responseFormatter(req, res, {
-                                data: data,
+                                output: errResponse.output,
                                 meta: meta,
                             })
                         );
-                    } else {
-                        // TODO: Remove `returnMeta` feature flag after next release
-                        res.status(meta.statusCode || 200).json(data);
+                        return;
                     }
+
+                    res.status(meta.statusCode || 200).json(
+                        responseFormatter(req, res, {
+                            data: data,
+                            meta: meta,
+                        })
+                    );
                 });
         } else {
             var requests = req.body && req.body.requests;

--- a/libs/fetcher.js
+++ b/libs/fetcher.js
@@ -536,7 +536,10 @@ Fetcher.middleware = function (options) {
                     if (err) {
                         var errResponse = getErrorResponse(err);
                         res.status(errResponse.statusCode).json(
-                            responseFormatter(req, res, errResponse.output)
+                            responseFormatter(req, res, {
+                                output: errResponse.output,
+                                meta: meta,
+                            })
                         );
                         return;
                     }

--- a/tests/functional/fetchr.test.js
+++ b/tests/functional/fetchr.test.js
@@ -140,11 +140,11 @@ describe('client/server integration', () => {
             expect(response).to.deep.equal({
                 statusCode: 0,
                 rawRequest: {
-                    url: 'http://localhost:3001/error?returnMeta=true',
+                    url: 'http://localhost:3001/error',
                     method: 'GET',
                     headers: { 'X-Requested-With': 'XMLHttpRequest' },
                 },
-                url: 'http://localhost:3001/error?returnMeta=true',
+                url: 'http://localhost:3001/error',
                 timeout: 3000,
             });
         });
@@ -163,13 +163,13 @@ describe('client/server integration', () => {
                 meta: { foo: 'bar' },
                 output: { message: 'error' },
                 rawRequest: {
-                    url: 'http://localhost:3000/api/error?returnMeta=true',
+                    url: 'http://localhost:3000/api/error',
                     method: 'GET',
                     headers: { 'X-Requested-With': 'XMLHttpRequest' },
                 },
                 statusCode: 400,
                 timeout: 3000,
-                url: 'http://localhost:3000/api/error?returnMeta=true',
+                url: 'http://localhost:3000/api/error',
             });
         });
 
@@ -189,13 +189,13 @@ describe('client/server integration', () => {
                 meta: {},
                 output: { message: 'unexpected' },
                 rawRequest: {
-                    url: 'http://localhost:3000/api/error;error=unexpected?returnMeta=true',
+                    url: 'http://localhost:3000/api/error;error=unexpected',
                     method: 'GET',
                     headers: { 'X-Requested-With': 'XMLHttpRequest' },
                 },
                 statusCode: 500,
                 timeout: 3000,
-                url: 'http://localhost:3000/api/error;error=unexpected?returnMeta=true',
+                url: 'http://localhost:3000/api/error;error=unexpected',
             });
         });
 
@@ -209,11 +209,11 @@ describe('client/server integration', () => {
                 statusCode: 404,
                 body: { error: 'page not found' },
                 rawRequest: {
-                    url: 'http://localhost:3000/non-existent/item?returnMeta=true',
+                    url: 'http://localhost:3000/non-existent/item',
                     method: 'GET',
                     headers: { 'X-Requested-With': 'XMLHttpRequest' },
                 },
-                url: 'http://localhost:3000/non-existent/item?returnMeta=true',
+                url: 'http://localhost:3000/non-existent/item',
                 timeout: 3000,
             });
         });
@@ -229,11 +229,11 @@ describe('client/server integration', () => {
             expect(response).to.deep.equal({
                 statusCode: 0,
                 rawRequest: {
-                    url: 'http://localhost:3000/api/error;error=timeout?returnMeta=true',
+                    url: 'http://localhost:3000/api/error;error=timeout',
                     method: 'GET',
                     headers: { 'X-Requested-With': 'XMLHttpRequest' },
                 },
-                url: 'http://localhost:3000/api/error;error=timeout?returnMeta=true',
+                url: 'http://localhost:3000/api/error;error=timeout',
                 timeout: 20,
             });
         });

--- a/tests/functional/fetchr.test.js
+++ b/tests/functional/fetchr.test.js
@@ -129,130 +129,277 @@ describe('client/server integration', () => {
     });
 
     describe('Error handling', () => {
-        it('can handle uncongifured server', async () => {
-            const response = await page.evaluate(() => {
-                const fetcher = new Fetchr({
-                    xhrPath: 'http://localhost:3001',
+        describe('GET', () => {
+            it('can handle unconfigured server', async () => {
+                const response = await page.evaluate(() => {
+                    const fetcher = new Fetchr({
+                        xhrPath: 'http://localhost:3001',
+                    });
+                    return fetcher.read('error', null).catch((err) => err);
                 });
-                return fetcher.read('error', null).catch((err) => err);
-            });
 
-            expect(response).to.deep.equal({
-                statusCode: 0,
-                rawRequest: {
+                expect(response).to.deep.equal({
+                    statusCode: 0,
+                    rawRequest: {
+                        url: 'http://localhost:3001/error',
+                        method: 'GET',
+                        headers: { 'X-Requested-With': 'XMLHttpRequest' },
+                    },
                     url: 'http://localhost:3001/error',
-                    method: 'GET',
-                    headers: { 'X-Requested-With': 'XMLHttpRequest' },
-                },
-                url: 'http://localhost:3001/error',
-                timeout: 3000,
-            });
-        });
-
-        it('can handle service expected errors', async () => {
-            const response = await page.evaluate(() => {
-                const fetcher = new Fetchr({});
-                return fetcher.read('error', null).catch((err) => err);
+                    timeout: 3000,
+                });
             });
 
-            expect(response).to.deep.equal({
-                body: {
-                    output: { message: 'error' },
+            it('can handle service expected errors', async () => {
+                const response = await page.evaluate(() => {
+                    const fetcher = new Fetchr({});
+                    return fetcher.read('error', null).catch((err) => err);
+                });
+
+                expect(response).to.deep.equal({
+                    body: {
+                        output: { message: 'error' },
+                        meta: { foo: 'bar' },
+                    },
                     meta: { foo: 'bar' },
-                },
-                meta: { foo: 'bar' },
-                output: { message: 'error' },
-                rawRequest: {
+                    output: { message: 'error' },
+                    rawRequest: {
+                        url: 'http://localhost:3000/api/error',
+                        method: 'GET',
+                        headers: { 'X-Requested-With': 'XMLHttpRequest' },
+                    },
+                    statusCode: 400,
+                    timeout: 3000,
                     url: 'http://localhost:3000/api/error',
-                    method: 'GET',
-                    headers: { 'X-Requested-With': 'XMLHttpRequest' },
-                },
-                statusCode: 400,
-                timeout: 3000,
-                url: 'http://localhost:3000/api/error',
-            });
-        });
-
-        it('can handle service unexpected errors', async () => {
-            const response = await page.evaluate(() => {
-                const fetcher = new Fetchr({});
-                return fetcher
-                    .read('error', { error: 'unexpected' })
-                    .catch((err) => err);
+                });
             });
 
-            expect(response).to.deep.equal({
-                body: {
-                    output: { message: 'unexpected' },
+            it('can handle service unexpected errors', async () => {
+                const response = await page.evaluate(() => {
+                    const fetcher = new Fetchr({});
+                    return fetcher
+                        .read('error', { error: 'unexpected' })
+                        .catch((err) => err);
+                });
+
+                expect(response).to.deep.equal({
+                    body: {
+                        output: { message: 'unexpected' },
+                        meta: {},
+                    },
                     meta: {},
-                },
-                meta: {},
-                output: { message: 'unexpected' },
-                rawRequest: {
+                    output: { message: 'unexpected' },
+                    rawRequest: {
+                        url: 'http://localhost:3000/api/error;error=unexpected',
+                        method: 'GET',
+                        headers: { 'X-Requested-With': 'XMLHttpRequest' },
+                    },
+                    statusCode: 500,
+                    timeout: 3000,
                     url: 'http://localhost:3000/api/error;error=unexpected',
-                    method: 'GET',
-                    headers: { 'X-Requested-With': 'XMLHttpRequest' },
-                },
-                statusCode: 500,
-                timeout: 3000,
-                url: 'http://localhost:3000/api/error;error=unexpected',
-            });
-        });
-
-        it('can handle incorrect api path', async () => {
-            const response = await page.evaluate(() => {
-                const fetcher = new Fetchr({ xhrPath: '/non-existent' });
-                return fetcher.read('item', null).catch((err) => err);
+                });
             });
 
-            expect(response).to.deep.equal({
-                statusCode: 404,
-                body: { error: 'page not found' },
-                rawRequest: {
+            it('can handle incorrect api path', async () => {
+                const response = await page.evaluate(() => {
+                    const fetcher = new Fetchr({ xhrPath: '/non-existent' });
+                    return fetcher.read('item', null).catch((err) => err);
+                });
+
+                expect(response).to.deep.equal({
+                    statusCode: 404,
+                    body: { error: 'page not found' },
+                    rawRequest: {
+                        url: 'http://localhost:3000/non-existent/item',
+                        method: 'GET',
+                        headers: { 'X-Requested-With': 'XMLHttpRequest' },
+                    },
                     url: 'http://localhost:3000/non-existent/item',
-                    method: 'GET',
-                    headers: { 'X-Requested-With': 'XMLHttpRequest' },
-                },
-                url: 'http://localhost:3000/non-existent/item',
-                timeout: 3000,
-            });
-        });
-
-        it('can handle timeouts', async () => {
-            const response = await page.evaluate(() => {
-                const fetcher = new Fetchr({});
-                return fetcher
-                    .read('error', { error: 'timeout' }, { timeout: 20 })
-                    .catch((err) => err);
+                    timeout: 3000,
+                });
             });
 
-            expect(response).to.deep.equal({
-                statusCode: 0,
-                rawRequest: {
+            it('can handle timeouts', async () => {
+                const response = await page.evaluate(() => {
+                    const fetcher = new Fetchr({});
+                    return fetcher
+                        .read('error', { error: 'timeout' }, { timeout: 20 })
+                        .catch((err) => err);
+                });
+
+                expect(response).to.deep.equal({
+                    statusCode: 0,
+                    rawRequest: {
+                        url: 'http://localhost:3000/api/error;error=timeout',
+                        method: 'GET',
+                        headers: { 'X-Requested-With': 'XMLHttpRequest' },
+                    },
                     url: 'http://localhost:3000/api/error;error=timeout',
-                    method: 'GET',
-                    headers: { 'X-Requested-With': 'XMLHttpRequest' },
-                },
-                url: 'http://localhost:3000/api/error;error=timeout',
-                timeout: 20,
+                    timeout: 20,
+                });
+            });
+
+            it('can retry failed requests', async () => {
+                const response = await page.evaluate(() => {
+                    const fetcher = new Fetchr({});
+                    return fetcher
+                        .read(
+                            'error',
+                            { error: 'retry' },
+                            { retry: { maxRetries: 2 } }
+                        )
+                        .catch((err) => err);
+                });
+
+                expect(response).to.deep.equal({
+                    data: { retry: 'ok' },
+                    meta: {},
+                });
             });
         });
 
-        it('can retry failed requests', async () => {
-            const response = await page.evaluate(() => {
-                const fetcher = new Fetchr({});
-                return fetcher
-                    .read(
-                        'error',
-                        { error: 'retry' },
-                        { retry: { maxRetries: 2 } }
-                    )
-                    .catch((err) => err);
+        describe('POST', () => {
+            it('can handle unconfigured server', async () => {
+                const response = await page.evaluate(() => {
+                    const fetcher = new Fetchr({
+                        xhrPath: 'http://localhost:3001',
+                    });
+                    return fetcher.create('error', null).catch((err) => err);
+                });
+
+                expect(response).to.deep.equal({
+                    statusCode: 0,
+                    rawRequest: {
+                        url: 'http://localhost:3001/',
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'X-Requested-With': 'XMLHttpRequest',
+                        },
+                    },
+                    url: 'http://localhost:3001/',
+                    timeout: 3000,
+                });
             });
 
-            expect(response).to.deep.equal({
-                data: { retry: 'ok' },
-                meta: {},
+            it('can handle service expected errors', async () => {
+                const response = await page.evaluate(() => {
+                    const fetcher = new Fetchr({});
+                    return fetcher.create('error', null).catch((err) => err);
+                });
+
+                expect(response).to.deep.equal({
+                    body: {
+                        output: { message: 'error' },
+                        meta: { foo: 'bar' },
+                    },
+                    meta: { foo: 'bar' },
+                    output: { message: 'error' },
+                    rawRequest: {
+                        url: 'http://localhost:3000/api',
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'X-Requested-With': 'XMLHttpRequest',
+                        },
+                    },
+                    statusCode: 400,
+                    timeout: 3000,
+                    url: 'http://localhost:3000/api',
+                });
+            });
+
+            it('can handle service unexpected errors', async () => {
+                const response = await page.evaluate(() => {
+                    const fetcher = new Fetchr({});
+                    return fetcher
+                        .create('error', { error: 'unexpected' })
+                        .catch((err) => err);
+                });
+
+                expect(response).to.deep.equal({
+                    body: {
+                        output: { message: 'unexpected' },
+                        meta: {},
+                    },
+                    meta: {},
+                    output: { message: 'unexpected' },
+                    rawRequest: {
+                        url: 'http://localhost:3000/api',
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'X-Requested-With': 'XMLHttpRequest',
+                        },
+                    },
+                    statusCode: 500,
+                    timeout: 3000,
+                    url: 'http://localhost:3000/api',
+                });
+            });
+
+            it('can handle incorrect api path', async () => {
+                const response = await page.evaluate(() => {
+                    const fetcher = new Fetchr({ xhrPath: '/non-existent' });
+                    return fetcher.create('item', null).catch((err) => err);
+                });
+
+                expect(response).to.deep.equal({
+                    statusCode: 404,
+                    body: { error: 'page not found' },
+                    rawRequest: {
+                        url: 'http://localhost:3000/non-existent',
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'X-Requested-With': 'XMLHttpRequest',
+                        },
+                    },
+                    url: 'http://localhost:3000/non-existent',
+                    timeout: 3000,
+                });
+            });
+
+            it('can handle timeouts', async () => {
+                const response = await page.evaluate(() => {
+                    const fetcher = new Fetchr({});
+                    return fetcher
+                        .create('error', { error: 'timeout' }, null, {
+                            timeout: 20,
+                        })
+                        .catch((err) => err);
+                });
+
+                expect(response).to.deep.equal({
+                    statusCode: 0,
+                    rawRequest: {
+                        url: 'http://localhost:3000/api',
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'X-Requested-With': 'XMLHttpRequest',
+                        },
+                    },
+                    url: 'http://localhost:3000/api',
+                    timeout: 20,
+                });
+            });
+
+            it('can retry failed requests', async () => {
+                const response = await page.evaluate(() => {
+                    const fetcher = new Fetchr({});
+                    return fetcher
+                        .create('error', { error: 'retry' }, null, {
+                            retry: { maxRetries: 2 },
+                            unsafeAllowRetry: true,
+                        })
+                        .catch((err) => err);
+                });
+
+                expect(response).to.deep.equal({
+                    data: { retry: 'ok' },
+                    meta: {},
+                });
             });
         });
     });

--- a/tests/functional/resources/error.js
+++ b/tests/functional/resources/error.js
@@ -30,6 +30,9 @@ const errorsService = {
         err.statusCode = 400;
         callback(err, null, { foo: 'bar' });
     },
+    create(req, resource, params, body, config, callback) {
+        this.read(req, resource, params, config, callback);
+    },
 };
 
 module.exports = {

--- a/tests/mock/MockErrorService.js
+++ b/tests/mock/MockErrorService.js
@@ -30,10 +30,10 @@ var MockErrorService = {
             // in our CORS test, we use regular query params instead
             // of matrix params for the params object will be empty
             // create params from req.query but omit the context
-            // values(i.e. cors & returnMeta)
+            // values(i.e. cors)
             params = {};
             for (const [key, value] of Object.entries(req.query)) {
-                if (['cors', 'returnMeta', '_csrf'].includes(key)) {
+                if (['cors', '_csrf'].includes(key)) {
                     continue;
                 }
                 params[key] = value;

--- a/tests/mock/MockService.js
+++ b/tests/mock/MockService.js
@@ -30,10 +30,10 @@ var MockService = {
             // in our CORS test, we use regular query params instead
             // of matrix params for the params object will be empty
             // create params from req.query but omit the context
-            // values(i.e. cors & returnMeta)
+            // values(i.e. cors)
             params = {};
             for (const [key, value] of Object.entries(req.query)) {
-                if (['cors', 'returnMeta', '_csrf'].includes(key)) {
+                if (['cors', '_csrf'].includes(key)) {
                     continue;
                 }
                 params[key] = value;

--- a/tests/unit/libs/fetcher.client.js
+++ b/tests/unit/libs/fetcher.client.js
@@ -110,7 +110,6 @@ describe('Client Fetcher', function () {
                 if (req.method === 'GET') {
                     expect(req.url).to.contain(DEFAULT_PATH + '/' + resource);
                     expect(req.url).to.contain('?_csrf=' + context._csrf);
-                    expect(req.url).to.contain('returnMeta=true');
                 } else if (req.method === 'POST') {
                     expect(req.url).to.equal(
                         DEFAULT_PATH + '?_csrf=' + context._csrf
@@ -133,7 +132,6 @@ describe('Client Fetcher', function () {
                 if (req.method === 'GET') {
                     expect(req.url).to.contain(corsPath);
                     expect(req.url).to.contain('_csrf=' + context._csrf);
-                    expect(req.url).to.contain('returnMeta=true');
                 } else if (req.method === 'POST') {
                     expect(req.url).to.contain(
                         corsPath + '/?_csrf=' + context._csrf
@@ -311,7 +309,6 @@ describe('Client Fetcher', function () {
                     expect(req.url).to.contain(DEFAULT_PATH + '/' + resource);
                     expect(req.url).to.contain('?_csrf=' + ctx._csrf);
                     expect(req.url).to.not.contain('random=' + ctx.random);
-                    expect(req.url).to.contain('returnMeta=true');
                 } else if (req.method === 'POST') {
                     expect(req.url).to.equal(
                         DEFAULT_PATH +

--- a/tests/unit/libs/fetcher.js
+++ b/tests/unit/libs/fetcher.js
@@ -329,27 +329,41 @@ describe('Server Fetcher', function () {
 
             it(
                 'should respond to POST api request with default error details',
-                makePostApiErrorTest({}, 500, { message: 'request failed' })
+                makePostApiErrorTest({}, 500, {
+                    meta: {},
+                    output: {
+                        message: 'request failed',
+                    },
+                })
             );
 
             it(
                 'should respond to POST api request with custom error status code',
                 makePostApiErrorTest({ statusCode: 400 }, 400, {
-                    message: 'request failed',
+                    meta: {},
+                    output: {
+                        message: 'request failed',
+                    },
                 })
             );
 
             it(
                 'should respond to POST api request with custom error message',
                 makePostApiErrorTest({ message: 'Error message...' }, 500, {
-                    message: 'Error message...',
+                    meta: {},
+                    output: {
+                        message: 'Error message...',
+                    },
                 })
             );
 
             it(
                 'should respond to POST api request with no leaked error information',
                 makePostApiErrorTest({ statusCode: 400, danger: 'zone' }, 400, {
-                    message: 'request failed',
+                    meta: {},
+                    output: {
+                        message: 'request failed',
+                    },
                 })
             );
 
@@ -365,7 +379,13 @@ describe('Server Fetcher', function () {
                             },
                         },
                         400,
-                        { message: 'custom message', foo: 'bar' }
+                        {
+                            meta: {},
+                            output: {
+                                message: 'custom message',
+                                foo: 'bar',
+                            },
+                        }
                     )
                 );
 
@@ -374,7 +394,10 @@ describe('Server Fetcher', function () {
                     makePostApiErrorTest(
                         { statusCode: 400, output: [1, 2] },
                         400,
-                        [1, 2]
+                        {
+                            meta: {},
+                            output: [1, 2],
+                        }
                     )
                 );
             });

--- a/tests/unit/libs/fetcher.js
+++ b/tests/unit/libs/fetcher.js
@@ -381,57 +381,6 @@ describe('Server Fetcher', function () {
         });
 
         describe('#GET', function () {
-            it('should respond to GET api request w/o meta', function (done) {
-                var operation = 'read';
-                var statusCodeSet = false;
-                var params = {
-                    uuids: [
-                        'cd7240d6-aeed-3fed-b63c-d7e99e21ca17',
-                        'cd7240d6-aeed-3fed-b63c-d7e99e21ca17',
-                    ],
-                    id: 'asdf',
-                };
-                var req = {
-                    method: 'GET',
-                    path:
-                        '/' +
-                        mockService.resource +
-                        ';' +
-                        qs.stringify(params, ';'),
-                    query: {},
-                };
-                var res = {
-                    json: function (response) {
-                        expect(response).to.exist;
-                        expect(response).to.not.be.empty;
-                        expect(response).to.not.contain.keys('data', 'meta');
-                        expect(response).to.contain.keys('operation', 'args');
-                        expect(response.operation.name).to.equal(operation);
-                        expect(response.operation.success).to.be.true;
-                        expect(response.args).to.contain.keys('params');
-                        expect(response.args.params).to.deep.equal(params);
-                        expect(statusCodeSet).to.be.true;
-                        done();
-                    },
-                    status: function (code) {
-                        expect(code).to.equal(200);
-                        statusCodeSet = true;
-                        return this;
-                    },
-                    send: function (code) {
-                        console.log(
-                            'Not Expected: middleware responded with',
-                            code
-                        );
-                    },
-                };
-                var next = function () {
-                    console.log('Not Expected: middleware skipped request');
-                };
-                var middleware = Fetcher.middleware({ pathPrefix: '/api' });
-
-                middleware(req, res, next);
-            });
             it('should respond to GET api request', function (done) {
                 var operation = 'read',
                     statusCodeSet = false,
@@ -449,9 +398,6 @@ describe('Server Fetcher', function () {
                             mockService.resource +
                             ';' +
                             qs.stringify(params, ';'),
-                        query: {
-                            returnMeta: true,
-                        },
                     },
                     res = {
                         json: function (response) {
@@ -516,9 +462,6 @@ describe('Server Fetcher', function () {
                             mockService.resource +
                             ';' +
                             qs.stringify(params, ';'),
-                        query: {
-                            returnMeta: true,
-                        },
                     },
                     res = {
                         json: function (response) {
@@ -589,9 +532,6 @@ describe('Server Fetcher', function () {
                             mockService.resource +
                             ';' +
                             qs.stringify(params, ';'),
-                        query: {
-                            returnMeta: true,
-                        },
                     },
                     res = {
                         json: function (response) {
@@ -658,9 +598,6 @@ describe('Server Fetcher', function () {
                             mockService.resource +
                             ';' +
                             qs.stringify(params, ';'),
-                        query: {
-                            returnMeta: true,
-                        },
                     },
                     res = {
                         json: function (response) {
@@ -726,9 +663,6 @@ describe('Server Fetcher', function () {
                             mockService.resource +
                             ';' +
                             qs.stringify(params, ';'),
-                        query: {
-                            returnMeta: true,
-                        },
                     },
                     res = {
                         json: function (response) {
@@ -829,27 +763,41 @@ describe('Server Fetcher', function () {
 
             it(
                 'should respond to GET api request with default error details',
-                makeGetApiErrorTest({}, 500, { message: 'request failed' })
+                makeGetApiErrorTest({}, 500, {
+                    meta: {},
+                    output: {
+                        message: 'request failed',
+                    },
+                })
             );
 
             it(
                 'should respond to GET api request with custom error status code',
                 makeGetApiErrorTest({ statusCode: 400 }, 400, {
-                    message: 'request failed',
+                    meta: {},
+                    output: {
+                        message: 'request failed',
+                    },
                 })
             );
 
             it(
                 'should respond to GET api request with no leaked error information',
                 makeGetApiErrorTest({ statusCode: 400, danger: 'zone' }, 400, {
-                    message: 'request failed',
+                    meta: {},
+                    output: {
+                        message: 'request failed',
+                    },
                 })
             );
 
             it(
                 'should respond to GET api request with custom error message',
                 makeGetApiErrorTest({ message: 'Error message...' }, 500, {
-                    message: 'Error message...',
+                    meta: {},
+                    output: {
+                        message: 'Error message...',
+                    },
                 })
             );
 
@@ -865,16 +813,28 @@ describe('Server Fetcher', function () {
                             },
                         },
                         400,
-                        { message: 'custom message', foo: 'bar' }
+                        {
+                            meta: {},
+                            output: {
+                                message: 'custom message',
+                                foo: 'bar',
+                            },
+                        }
                     )
                 );
 
                 it(
                     'using json array',
                     makeGetApiErrorTest(
-                        { statusCode: 400, output: [1, 2] },
+                        {
+                            statusCode: 400,
+                            output: [1, 2],
+                        },
                         400,
-                        [1, 2]
+                        {
+                            meta: {},
+                            output: [1, 2],
+                        }
                     )
                 );
             });
@@ -1017,9 +977,6 @@ describe('Server Fetcher', function () {
                             mockService.resource +
                             ';' +
                             qs.stringify(params, ';'),
-                        query: {
-                            returnMeta: true,
-                        },
                     };
                     var res = {
                         json: function (response) {
@@ -1171,9 +1128,6 @@ describe('Server Fetcher', function () {
                     mockService.resource +
                     ';' +
                     qs.stringify(params, ';'),
-                query: {
-                    returnMeta: true,
-                },
             };
             var res = {
                 json: function (response) {


### PR DESCRIPTION
`returnMeta` query param was introduced in order to handle a response format update from the server. There was a time that we would return the data from the resources without making any change. When `returnMeta` was introduced, we started formatting the response as following:

```js
// successful responses:
{
    data: serviceResponseData,
    meta: serviceResponseMeta,
}

// error responses:
{
    output: serviceErrorOutput,
    meta: serviceResponseMeta,
}
```
`returnMeta` was then added to prevent outdated clients to break because of the new format. Years have passed and all browsers should have a fresh copy of fetchr by now. Therefore, we can remove the support for it as requested in the TODO comments (ex. https://github.com/yahoo/fetchr/blob/241a71c204b17f25f7c5ff403e054ab70782425d/libs/fetcher.client.js#L272).

One caveat though: when the new format was added, we forgot to update the POST error responses. This PR also addresses this issue.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
