### PR TITLE
client: remove support for custom request Content-type

### DIFF
--- a/libs/util/http.client.js
+++ b/libs/util/http.client.js
@@ -7,8 +7,6 @@
  * @module rest-http
  */
 
-var forEach = require('./forEach');
-
 /*
  * Default configurations:
  *   timeout: timeout (in ms) for each request
@@ -23,44 +21,23 @@ var DEFAULT_CONFIG = {
         },
         unsafeAllowRetry: false,
     },
-    CONTENT_TYPE = 'Content-Type',
-    TYPE_JSON = 'application/json',
     METHOD_GET = 'GET',
     METHOD_POST = 'POST';
 
 var INITIAL_ATTEMPT = 0;
 
-function normalizeHeaders(headers, method, isCors) {
-    var normalized = {};
+function normalizeHeaders(rawHeaders, method, isCors) {
+    var headers = Object.assign({}, rawHeaders);
+
     if (!isCors) {
-        normalized['X-Requested-With'] = 'XMLHttpRequest';
-    }
-    var needContentType = method === METHOD_POST;
-    forEach(headers, function (v, field) {
-        if (field.toLowerCase() === 'content-type') {
-            if (needContentType) {
-                normalized[CONTENT_TYPE] = v;
-            }
-        } else {
-            normalized[field] = v;
-        }
-    });
-
-    if (needContentType && !normalized[CONTENT_TYPE]) {
-        normalized[CONTENT_TYPE] = TYPE_JSON;
+        headers['X-Requested-With'] = 'XMLHttpRequest';
     }
 
-    return normalized;
-}
-
-function isContentTypeJSON(headers) {
-    if (!headers[CONTENT_TYPE]) {
-        return false;
+    if (method === METHOD_POST) {
+        headers['Content-Type'] = 'application/json';
     }
 
-    return headers[CONTENT_TYPE].split(';').some(function (part) {
-        return part.trim().toLowerCase() === TYPE_JSON;
-    });
+    return headers;
 }
 
 function shouldRetry(method, config, statusCode, attempt) {
@@ -164,7 +141,7 @@ function doRequest(method, url, headers, data, config, attempt, callback) {
         },
     };
     if (data != null) {
-        options.data = isContentTypeJSON(headers) ? JSON.stringify(data) : data;
+        options.data = JSON.stringify(data);
     }
     return io(url, options);
 }

--- a/libs/util/http.client.js
+++ b/libs/util/http.client.js
@@ -26,8 +26,7 @@ var DEFAULT_CONFIG = {
     CONTENT_TYPE = 'Content-Type',
     TYPE_JSON = 'application/json',
     METHOD_GET = 'GET',
-    METHOD_POST = 'POST',
-    NULL = null;
+    METHOD_POST = 'POST';
 
 var INITIAL_ATTEMPT = 0;
 
@@ -137,7 +136,7 @@ function doRequest(method, url, headers, data, config, attempt, callback) {
         withCredentials: config.withCredentials,
         on: {
             success: function (err, response) {
-                callback(NULL, response);
+                callback(null, response);
             },
             failure: function (err, response) {
                 if (!shouldRetry(method, config, response.status, attempt)) {
@@ -164,7 +163,7 @@ function doRequest(method, url, headers, data, config, attempt, callback) {
             },
         },
     };
-    if (data !== undefined && data !== NULL) {
+    if (data != null) {
         options.data = isContentTypeJSON(headers) ? JSON.stringify(data) : data;
     }
     return io(url, options);
@@ -288,7 +287,7 @@ module.exports = {
             METHOD_GET,
             url,
             headers,
-            NULL,
+            null,
             config,
             INITIAL_ATTEMPT,
             callback


### PR DESCRIPTION
GET requests do not have a content, so no content-type header needed.

POST requests, in theory, could have any content-type since users could use any kind of express middleware that would populate req.body. The only use case that I see is to upload pictures. One could use a multipart form data to do that. But this person would need to know fetchr middleware implementation in order to make it work properly. But I bet that we all know better options to upload media that would be easier than to hack fetchr. 

So, IMO, it doesn't make sense to provide this feature. Am I missing something? 

What I'm trying to do now is to make the requests/responses as consistent as possible so we can simplify the code. I'm mainly concerned about error handling, this is where the code here is the ugliest IMO. The error object is inconsistent for different kinds of errors. This makes it hard to build proper errors handlers (ex. an integration with newrelic, sentry or any custom error dashboard).

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
