### PR TITLE
feat: add resource name in POST path requests

### DIFF
--- a/libs/fetcher.client.js
+++ b/libs/fetcher.client.js
@@ -309,7 +309,7 @@ function executeRequest(request, resolve, reject) {
         requests: requests,
         context: request.options.context,
     }; // TODO: remove. leave here for now for backward compatibility
-    uri = request._constructGroupUri(uri);
+    uri = request._constructPostUri(uri);
     allow_retry_post = request.operation === OP_READ;
     return REST.post(
         uri,
@@ -339,11 +339,11 @@ function executeRequest(request, resolve, reject) {
 
 /**
  * Build a final uri by adding query params to base uri from this.context
- * @method _constructGroupUri
+ * @method _constructPostUri
  * @param {String} uri the base uri
  * @private
  */
-Request.prototype._constructGroupUri = function (uri) {
+Request.prototype._constructPostUri = function (uri) {
     var query = [];
     var final_uri = uri;
     forEach(

--- a/libs/fetcher.client.js
+++ b/libs/fetcher.client.js
@@ -346,6 +346,15 @@ function executeRequest(request, resolve, reject) {
 Request.prototype._constructPostUri = function (uri) {
     var query = [];
     var final_uri = uri;
+
+    // We only want to append the resource if the uri is the fetchr
+    // one. If users set a custom uri (through clientConfig method or
+    // by passing a config obejct to the request), we should not
+    // modify it.
+    if (!this._clientConfig.uri) {
+        final_uri += '/' + this.resource;
+    }
+
     forEach(
         pickContext(this.options.context, this.options.contextPicker, 'POST'),
         function eachContext(v, k) {

--- a/tests/functional/fetchr.test.js
+++ b/tests/functional/fetchr.test.js
@@ -270,14 +270,14 @@ describe('client/server integration', () => {
                 expect(response).to.deep.equal({
                     statusCode: 0,
                     rawRequest: {
-                        url: 'http://localhost:3001/',
+                        url: 'http://localhost:3001/error',
                         method: 'POST',
                         headers: {
                             'Content-Type': 'application/json',
                             'X-Requested-With': 'XMLHttpRequest',
                         },
                     },
-                    url: 'http://localhost:3001/',
+                    url: 'http://localhost:3001/error',
                     timeout: 3000,
                 });
             });
@@ -296,7 +296,7 @@ describe('client/server integration', () => {
                     meta: { foo: 'bar' },
                     output: { message: 'error' },
                     rawRequest: {
-                        url: 'http://localhost:3000/api',
+                        url: 'http://localhost:3000/api/error',
                         method: 'POST',
                         headers: {
                             'Content-Type': 'application/json',
@@ -305,7 +305,7 @@ describe('client/server integration', () => {
                     },
                     statusCode: 400,
                     timeout: 3000,
-                    url: 'http://localhost:3000/api',
+                    url: 'http://localhost:3000/api/error',
                 });
             });
 
@@ -325,7 +325,7 @@ describe('client/server integration', () => {
                     meta: {},
                     output: { message: 'unexpected' },
                     rawRequest: {
-                        url: 'http://localhost:3000/api',
+                        url: 'http://localhost:3000/api/error',
                         method: 'POST',
                         headers: {
                             'Content-Type': 'application/json',
@@ -334,7 +334,7 @@ describe('client/server integration', () => {
                     },
                     statusCode: 500,
                     timeout: 3000,
-                    url: 'http://localhost:3000/api',
+                    url: 'http://localhost:3000/api/error',
                 });
             });
 
@@ -348,14 +348,14 @@ describe('client/server integration', () => {
                     statusCode: 404,
                     body: { error: 'page not found' },
                     rawRequest: {
-                        url: 'http://localhost:3000/non-existent',
+                        url: 'http://localhost:3000/non-existent/item',
                         method: 'POST',
                         headers: {
                             'Content-Type': 'application/json',
                             'X-Requested-With': 'XMLHttpRequest',
                         },
                     },
-                    url: 'http://localhost:3000/non-existent',
+                    url: 'http://localhost:3000/non-existent/item',
                     timeout: 3000,
                 });
             });
@@ -373,14 +373,14 @@ describe('client/server integration', () => {
                 expect(response).to.deep.equal({
                     statusCode: 0,
                     rawRequest: {
-                        url: 'http://localhost:3000/api',
+                        url: 'http://localhost:3000/api/error',
                         method: 'POST',
                         headers: {
                             'Content-Type': 'application/json',
                             'X-Requested-With': 'XMLHttpRequest',
                         },
                     },
-                    url: 'http://localhost:3000/api',
+                    url: 'http://localhost:3000/api/error',
                     timeout: 20,
                 });
             });

--- a/tests/unit/libs/fetcher.client.js
+++ b/tests/unit/libs/fetcher.client.js
@@ -112,7 +112,11 @@ describe('Client Fetcher', function () {
                     expect(req.url).to.contain('?_csrf=' + context._csrf);
                 } else if (req.method === 'POST') {
                     expect(req.url).to.equal(
-                        DEFAULT_PATH + '?_csrf=' + context._csrf
+                        DEFAULT_PATH +
+                            '/' +
+                            resource +
+                            '?_csrf=' +
+                            context._csrf
                     );
                 }
             };
@@ -134,7 +138,7 @@ describe('Client Fetcher', function () {
                     expect(req.url).to.contain('_csrf=' + context._csrf);
                 } else if (req.method === 'POST') {
                     expect(req.url).to.contain(
-                        corsPath + '/?_csrf=' + context._csrf
+                        '/' + resource + '?_csrf=' + context._csrf
                     );
                 }
             };
@@ -312,6 +316,8 @@ describe('Client Fetcher', function () {
                 } else if (req.method === 'POST') {
                     expect(req.url).to.equal(
                         DEFAULT_PATH +
+                            '/' +
+                            resource +
                             '?_csrf=' +
                             ctx._csrf +
                             '&random=' +


### PR DESCRIPTION
Currently, we only add the resource name in the path for GET requests:

`fetchr.read('resource-name')` => `/api/resource-name`.

But we never do it for POST requests:

`fetchr.read('resource-name').params(hugePayload)` => `/api`.

This behavior makes it hard to build monitoring tools on top of it. For example, one could have a gateway in front of `fetchr` that monitors the response success rate per path and triggers an alert if the rate drops. For GET requests, it is easy to spot which resource is the faulty one, but for POST requests it's just impossible without diving into the logs of the service where fetchr is running. It's definitely doable, but not easy if the team that manages the gateway have no idea what is behind it.

Another challenge would be to add a circuit breaker per resource. Currently we would need to parse the whole request to implement it (which requires knowledge about how fetchr works internally). But if we always have the resource in the path, then it would be way easier.

In this PR, I just did the least effort change: add the resource in the path if user haven't provided a custom path. But if you think the general idea is valid but the implementation could be different, as always, I'm open to change it :)

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
