### PR TITLE
refactor: use modern javascript in the server code

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,0 @@
-/**
- * Copyright 2014, Yahoo! Inc.
- * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
- */
-module.exports = require('./libs/fetcher');

--- a/libs/fetcher.js
+++ b/libs/fetcher.js
@@ -69,20 +69,25 @@ function getErrorResponse(err) {
 /**
  * A Request instance represents a single fetcher request.
  * The constructor requires `operation` (CRUD) and `resource`.
- * @class Request
- * @param {String} operation The CRUD operation name: 'create|read|update|delete'.
- * @param {String} resource name of service
- * @param {Object} options configuration options for Request
- * @param {Object} [options.req] The request object from express/connect.  It can contain per-request/context data.
- * @param {Array} [options.serviceMeta] Array to hold per-request/session metadata from all service calls.
- * @param {Function} [options.statsCollector] The function will be invoked with 1 argument:
- *      the stats object, which contains resource, operation, params (request params),
- *      statusCode, err, and time (elapsed time)
- * @param {Function} [options.paramsProcessor] The function will be invoked with 3 arguments:
- *      the req object, the serviceInfo object, and the params object.  It is expected to return the processed params object.
- * @constructor
  */
 class Request {
+    /**
+     * @param {String} operation The CRUD operation name: 'create|read|update|delete'.
+     * @param {String} resource name of service
+     * @param {Object} options configuration options for Request
+     * @param {Object} [options.req] The request object from
+     * express/connect. It can contain per-request/context data.
+     * @param {Array} [options.serviceMeta] Array to hold
+     * per-request/session metadata from all service calls.
+     * @param {Function} [options.statsCollector] The function will be
+     * invoked with 1 argument: the stats object, which contains
+     * resource, operation, params (request params), statusCode, err,
+     * and time (elapsed time)
+     * @param {Function} [options.paramsProcessor] The function will
+     * be invoked with 3 arguments: the req object, the serviceInfo
+     * object, and the params object.  It is expected to return the
+     * processed params object.
+     */
     constructor(operation, resource, options = {}) {
         if (!resource) {
             throw new Error('Resource is required for a fetcher request');
@@ -102,10 +107,9 @@ class Request {
 
     /**
      * Add params to this fetcher request
-     * @method params
-     * @memberof Request
-     * @param {Object} params Information carried in query and matrix parameters in typical REST API
-     * @chainable
+     * @param {Object} params Information carried in query and matrix
+     * parameters in typical REST API.
+     * @returns {this}
      */
     params(params) {
         this._params =
@@ -121,10 +125,10 @@ class Request {
 
     /**
      * Add body to this fetcher request
-     * @method body
-     * @memberof Request
-     * @param {Object} body The JSON object that contains the resource data being updated for this request. Not used for read and delete operations.
-     * @chainable
+     * @param {Object} body The JSON object that contains the resource
+     * data being updated for this request. Not used for read and
+     * delete operations.
+     * @returns {this}
      */
     body(body) {
         this._body = body;
@@ -132,11 +136,9 @@ class Request {
     }
 
     /**
-     * Add clientConfig to this fetcher request
-     * @method config
-     * @memberof Request
+     * Add clientConfig to this fetcher request.
      * @param {Object} config config for this fetcher request
-     * @chainable
+     * @returns {this}
      */
     clientConfig(config) {
         this._clientConfig = config;
@@ -144,8 +146,8 @@ class Request {
     }
 
     /**
-     * capture meta data; capture stats for this request and pass
-     * stats data to options.statsCollector
+     * Capture meta data; capture stats for this request and pass
+     * stats data to options.statsCollector.
      * @param {Object} errData  The error response for failed request
      * @param {Object} result  The response data for successful request
      */
@@ -171,9 +173,8 @@ class Request {
 
     /**
      * Execute this fetcher request and call callback.
-     * @method end
-     * @memberof Request
-     * @param {Fetcher~fetcherCallback} callback callback invoked when service is complete.
+     * @param {fetcherCallback} callback callback invoked when service
+     * is complete.
      */
     end(callback) {
         this._startTime = Date.now();
@@ -208,7 +209,6 @@ class Request {
 
 /**
  * Execute and resolve/reject this fetcher request
- * @method executeRequest
  * @param {Object} request Request instance object
  * @param {Function} resolve function to call when request fulfilled
  * @param {Function} reject function to call when request rejected
@@ -252,14 +252,19 @@ class Fetcher {
      * Provides interface to register data services and
      * to later access those services.
      * @class Fetcher
-     * @param {Object} options configuration options for Fetcher
-     * @param {Object} [options.req] The express request object.  It can contain per-request/context data.
-     * @param {string} [options.xhrPath="/api"] The path for XHR requests. Will be ignored server side.
-     * @param {Function} [options.statsCollector] The function will be invoked with 1 argument:
-     *      the stats object, which contains resource, operation, params (request params),
-     *      statusCode, err, and time (elapsed time)
-     * @param {Function} [options.paramsProcessor] The function will be invoked with 3 arguments:
-     *      the req object, the serviceInfo object, and the params object.  It is expected to return the processed params object.
+     * @param {Object} options configuration options for Fetcher.
+     * @param {Object} [options.req] The express request object. It
+     * can contain per-request/context data.
+     * @param {string} [options.xhrPath="/api"] The path for XHR
+     * requests. Will be ignored server side.
+     * @param {Function} [options.statsCollector] The function will be
+     * invoked with 1 argument: the stats object, which contains
+     * resource, operation, params (request params), statusCode, err,
+     * and time (elapsed time).
+     * @param {Function} [options.paramsProcessor] The function will
+     * be invoked with 3 arguments: the req object, the serviceInfo
+     * object, and the params object.  It is expected to return the
+     * processed params object.
      * @constructor
      */
     constructor(options = {}) {
@@ -273,10 +278,8 @@ class Fetcher {
     static _deprecatedServicesDefinitions = [];
 
     /**
-     * DEPRECATED
      * Register a data fetcher
-     * @method registerFetcher
-     * @memberof Fetcher
+     * @deprecated Use registerService.
      * @param {Function} fetcher
      */
     static registerFetcher(fetcher) {
@@ -290,8 +293,6 @@ class Fetcher {
 
     /**
      * Register a data service
-     * @method registerService
-     * @memberof Fetcher
      * @param {Function} service
      */
     static registerService(service) {
@@ -318,10 +319,9 @@ class Fetcher {
     }
 
     /**
-     * DEPRECATED
      * Retrieve a data fetcher by name
-     * @method getFetcheresourceof Fetcher
-     * @param {String} name oresource @returns {Function} fetcher
+     * @deprecated Use getService
+     * @param {String} name oresource @returns {Function} fetcher.
      */
     static getFetcher(name) {
         // TODO: Uncomment warnings in next minor release
@@ -334,8 +334,6 @@ class Fetcher {
 
     /**
      * Retrieve a data service by name
-     * @method getService
-     * @memberof Fetcher
      * @param {String} name of service
      * @returns {Function} service
      */
@@ -352,8 +350,6 @@ class Fetcher {
 
     /**
      * Returns true if service with name has been registered
-     * @method isRegistered
-     * @memberof Fetcher
      * @param {String} name of service
      * @returns {Boolean} true if service with name was registered
      */
@@ -362,23 +358,23 @@ class Fetcher {
     }
 
     /**
- * Returns express/connect middleware for Fetcher
- * @method middleware
- * @memberof Fetcher
- * @param {Object} [options] Optional configurations
- * @param {Function} [options.responseFormatter=no op function] Function to modify the response
-            before sending to client. First argument is the HTTP request object,
-            second argument is the HTTP response object and the third argument is the service data object.
- * @param {Function} [options.statsCollector] The function will be invoked with 1 argument:
-           the stats object, which contains resource, operation, params (request params),
-           statusCode, err, and time (elapsed time)
- * @param {Function} [options.paramsProcessor] The function will be invoked with 3 arguments:
- *         the req object, the serviceInfo object, and the params object.  It is expected to return the processed params object.
- * @returns {Function} middleware
- *     @param {Object} req
- *     @param {Object} res
- *     @param {Object} next
- */
+     * Returns express/connect middleware for Fetcher
+     * @param {Object} [options] Optional configurations
+     * @param {Function} [options.responseFormatter=no op function]
+     * Function to modify the response before sending to client. First
+     * argument is the HTTP request object, second argument is the
+     * HTTP response object and the third argument is the service data
+     * object.
+     * @param {Function} [options.statsCollector] The function will be
+     * invoked with 1 argument: the stats object, which contains
+     * resource, operation, params (request params), statusCode, err,
+     * and time (elapsed time).
+     * @param {Function} [options.paramsProcessor] The function will
+     * be invoked with 3 arguments: the req object, the serviceInfo
+     * object, and the params object.  It is expected to return the
+     * processed params object.
+     * @returns {Function} middleware
+     */
     static middleware(options = {}) {
         const responseFormatter =
             options.responseFormatter || ((req, res, data) => data);
@@ -528,20 +524,16 @@ following services definitions: ${deprecatedServices}.`);
         };
     }
 
-    // ------------------------------------------------------------------
-    // CRUD Data Access Wrapper Methods
-    // ------------------------------------------------------------------
-
     /**
      * read operation (read as in CRUD).
-     * @method read
-     * @memberof Fetcher.prototype
-     * @param {String} resource  The resource name
-     * @param {Object} params    The parameters identify the resource, and along with information
-     *                           carried in query and matrix parameters in typical REST API
-     * @param {Object} [config={}] The config object.  It can contain "config" for per-request config data.
-     * @param {Fetcher~fetcherCallback} callback callback invoked when fetcher is complete.
-     * @static
+     * @param {String} resource The resource name.
+     * @param {Object} params The parameters identify the resource,
+     * and along with information carried in query and matrix
+     * parameters in typical REST API.
+     * @param {Object} [config={}] The config object. It can contain
+     * "config" for per-request config data.
+     * @param {fetcherCallback} callback callback invoked when fetcher
+     * is complete.
      */
     read(resource, params, config, callback) {
         const request = new Request('read', resource, {
@@ -566,16 +558,17 @@ following services definitions: ${deprecatedServices}.`);
     }
 
     /**
-     * create operation (create as in CRUD).
-     * @method create
-     * @memberof Fetcher.prototype
-     * @param {String} resource  The resource name
-     * @param {Object} params    The parameters identify the resource, and along with information
-     *                           carried in query and matrix parameters in typical REST API
-     * @param {Object} body      The JSON object that contains the resource data that is being created
-     * @param {Object} [config={}] The config object.  It can contain "config" for per-request config data.
-     * @param {Fetcher~fetcherCallback} callback callback invoked when fetcher is complete.
-     * @static
+     * Create operation (create as in CRUD).
+     * @param {String} resource The resource name.
+     * @param {Object} params The parameters identify the resource,
+     * and along with information carried in query and matrix
+     * parameters in typical REST API.
+     * @param {Object} body The JSON object that contains the resource
+     * data that is being created.
+     * @param {Object} [config={}] The config object. It can contain
+     * "config" for per-request config data.
+     * @param {fetcherCallback} callback callback invoked when fetcher
+     * is complete.
      */
     create(resource, params, body, config, callback) {
         const request = new Request('create', resource, {
@@ -604,16 +597,17 @@ following services definitions: ${deprecatedServices}.`);
     }
 
     /**
-     * update operation (update as in CRUD).
-     * @method update
-     * @memberof Fetcher.prototype
-     * @param {String} resource  The resource name
-     * @param {Object} params    The parameters identify the resource, and along with information
-     *                           carried in query and matrix parameters in typical REST API
-     * @param {Object} body      The JSON object that contains the resource data that is being updated
-     * @param {Object} [config={}] The config object.  It can contain "config" for per-request config data.
-     * @param {Fetcher~fetcherCallback} callback callback invoked when fetcher is complete.
-     * @static
+     * Update operation (update as in CRUD).
+     * @param {String} resource The resource name
+     * @param {Object} params The parameters identify the resource,
+     * and along with information carried in query and matrix
+     * parameters in typical REST API.
+     * @param {Object} body The JSON object that contains the resource
+     * data that is being updated.
+     * @param {Object} [config={}] The config object. It can contain
+     * "config" for per-request config data.
+     * @param {fetcherCallback} callback callback invoked when
+     * fetcher is complete.
      */
     update(resource, params, body, config, callback) {
         const request = new Request('update', resource, {
@@ -642,15 +636,15 @@ following services definitions: ${deprecatedServices}.`);
     }
 
     /**
-     * delete operation (delete as in CRUD).
-     * @method delete
-     * @memberof Fetcher.prototype
-     * @param {String} resource  The resource name
-     * @param {Object} params    The parameters identify the resource, and along with information
-     *                           carried in query and matrix parameters in typical REST API
-     * @param {Object} [config={}] The config object.  It can contain "config" for per-request config data.
-     * @param {Fetcher~fetcherCallback} callback callback invoked when fetcher is complete.
-     * @static
+     * Delete operation (delete as in CRUD).
+     * @param {String} resource The resource name
+     * @param {Object} params The parameters identify the resource,
+     * and along with information carried in query and matrix
+     * parameters in typical REST API.
+     * @param {Object} [config={}] The config object. It can contain
+     * "config" for per-request config data.
+     * @param {fetcherCallback} callback callback invoked when
+     * fetcher is complete.
      */
     delete(resource, params, config, callback) {
         const request = new Request('delete', resource, {
@@ -676,12 +670,12 @@ following services definitions: ${deprecatedServices}.`);
     }
 
     /**
-     * update fetchr options
-     * @method updateOptions
-     * @memberof Fetcher.prototype
-     * @param {Object} options configuration options for Fetcher
-     * @param {Object} [options.req] The request object.  It can contain per-request/context data.
-     * @param {string} [options.xhrPath="/api"] The path for XHR requests. Will be ignored server side.
+     * Update fetchr options
+     * @param {Object} options configuration options for Fetcher.
+     * @param {string} [options.xhrPath="/api"] The path for XHR
+     * requests. Will be ignored server side.
+     * @param {Object} [options.req] The request object. It can
+     * contain per-request/context data.
      */
     updateOptions(options) {
         this.options = Object.assign(this.options, options);
@@ -689,7 +683,8 @@ following services definitions: ${deprecatedServices}.`);
     }
 
     /**
-     * Get all the aggregated metadata sent data services in this request
+     * Get all the aggregated metadata sent data services in this
+     * request.
      */
     getServiceMeta() {
         return this._serviceMeta;
@@ -699,8 +694,10 @@ following services definitions: ${deprecatedServices}.`);
 module.exports = Fetcher;
 
 /**
- * @callback Fetcher~fetcherCallback
- * @param {Object} err  The request error, pass null if there was no error. The data and meta parameters will be ignored if this parameter is not null.
+ * @callback fetcherCallback
+ * @param {Object} err The request error, pass null if there was no
+ * error. The data and meta parameters will be ignored if this
+ * parameter is not null.
  * @param {number} [err.statusCode=500] http status code to return
  * @param {string} [err.message=request failed] http response body
  * @param {Object} data request result

--- a/libs/fetcher.js
+++ b/libs/fetcher.js
@@ -246,121 +246,122 @@ function executeRequest(request, resolve, reject) {
     }
 }
 
-/**
- * Fetcher class for the server.
- * Provides interface to register data services and
- * to later access those services.
- * @class Fetcher
- * @param {Object} options configuration options for Fetcher
- * @param {Object} [options.req] The express request object.  It can contain per-request/context data.
- * @param {string} [options.xhrPath="/api"] The path for XHR requests. Will be ignored server side.
- * @param {Function} [options.statsCollector] The function will be invoked with 1 argument:
- *      the stats object, which contains resource, operation, params (request params),
- *      statusCode, err, and time (elapsed time)
- * @param {Function} [options.paramsProcessor] The function will be invoked with 3 arguments:
- *      the req object, the serviceInfo object, and the params object.  It is expected to return the processed params object.
- * @constructor
- */
-function Fetcher(options = {}) {
-    this.options = options;
-    this.req = this.options.req || {};
-    this._serviceMeta = [];
-}
-
-Fetcher.services = {};
-
-Fetcher._deprecatedServicesDefinitions = [];
-
-/**
- * DEPRECATED
- * Register a data fetcher
- * @method registerFetcher
- * @memberof Fetcher
- * @param {Function} fetcher
- */
-Fetcher.registerFetcher = function (fetcher) {
-    // TODO: Uncomment warnings in next minor release
-    // if ('production' !== process.env.NODE_ENV) {
-    //     console.warn('Fetcher.registerFetcher is deprecated. ' +
-    //         'Please use Fetcher.registerService instead.');
-    // }
-    return Fetcher.registerService(fetcher);
-};
-
-/**
- * Register a data service
- * @method registerService
- * @memberof Fetcher
- * @param {Function} service
- */
-Fetcher.registerService = function (service) {
-    if (!service) {
-        throw new Error(
-            'Fetcher.registerService requires a service definition (ex. registerService(service)).'
-        );
+class Fetcher {
+    /**
+     * Fetcher class for the server.
+     * Provides interface to register data services and
+     * to later access those services.
+     * @class Fetcher
+     * @param {Object} options configuration options for Fetcher
+     * @param {Object} [options.req] The express request object.  It can contain per-request/context data.
+     * @param {string} [options.xhrPath="/api"] The path for XHR requests. Will be ignored server side.
+     * @param {Function} [options.statsCollector] The function will be invoked with 1 argument:
+     *      the stats object, which contains resource, operation, params (request params),
+     *      statusCode, err, and time (elapsed time)
+     * @param {Function} [options.paramsProcessor] The function will be invoked with 3 arguments:
+     *      the req object, the serviceInfo object, and the params object.  It is expected to return the processed params object.
+     * @constructor
+     */
+    constructor(options = {}) {
+        this.options = options;
+        this.req = this.options.req || {};
+        this._serviceMeta = [];
     }
 
-    let resource;
-    if (typeof service.resource !== 'undefined') {
-        resource = service.resource;
-    } else if (typeof service.name !== 'undefined') {
-        resource = service.name;
-        Fetcher._deprecatedServicesDefinitions.push(resource);
-    } else {
-        throw new Error(
-            '"resource" property is missing in service definition.'
-        );
+    static services = {};
+
+    static _deprecatedServicesDefinitions = [];
+
+    /**
+     * DEPRECATED
+     * Register a data fetcher
+     * @method registerFetcher
+     * @memberof Fetcher
+     * @param {Function} fetcher
+     */
+    static registerFetcher(fetcher) {
+        // TODO: Uncomment warnings in next minor release
+        // if ('production' !== process.env.NODE_ENV) {
+        //     console.warn('Fetcher.registerFetcher is deprecated. ' +
+        //         'Please use Fetcher.registerService instead.');
+        // }
+        return Fetcher.registerService(fetcher);
     }
 
-    Fetcher.services[resource] = service;
-    return;
-};
+    /**
+     * Register a data service
+     * @method registerService
+     * @memberof Fetcher
+     * @param {Function} service
+     */
+    static registerService(service) {
+        if (!service) {
+            throw new Error(
+                'Fetcher.registerService requires a service definition (ex. registerService(service)).'
+            );
+        }
 
-/**
- * DEPRECATED
- * Retrieve a data fetcher by name
- * @method getFetcheresourceof Fetcher
- * @param {String} name oresource @returns {Function} fetcher
- */
-Fetcher.getFetcher = function (name) {
-    // TODO: Uncomment warnings in next minor release
-    // if ('production' !== process.env.NODE_ENV) {
-    //     console.warn('Fetcher.getFetcher is deprecated. ' +
-    //         'Please use Fetcher.getService instead.');
-    // }
-    return Fetcher.getService(name);
-};
+        let resource;
+        if (typeof service.resource !== 'undefined') {
+            resource = service.resource;
+        } else if (typeof service.name !== 'undefined') {
+            resource = service.name;
+            Fetcher._deprecatedServicesDefinitions.push(resource);
+        } else {
+            throw new Error(
+                '"resource" property is missing in service definition.'
+            );
+        }
 
-/**
- * Retrieve a data service by name
- * @method getService
- * @memberof Fetcher
- * @param {String} name of service
- * @returns {Function} service
- */
-Fetcher.getService = function (name) {
-    //Access service by name
-    const service = Fetcher.isRegistered(name);
-    if (!service) {
-        throw new Error(
-            `Service "${sanitizeResourceName(name)}" could not be found`
-        );
+        Fetcher.services[resource] = service;
+        return;
     }
-    return service;
-};
 
-/**
- * Returns true if service with name has been registered
- * @method isRegistered
- * @memberof Fetcher
- * @param {String} name of service
- * @returns {Boolean} true if service with name was registered
- */
-Fetcher.isRegistered = function (name) {
-    return name && Fetcher.services[name.split('.')[0]];
-};
+    /**
+     * DEPRECATED
+     * Retrieve a data fetcher by name
+     * @method getFetcheresourceof Fetcher
+     * @param {String} name oresource @returns {Function} fetcher
+     */
+    static getFetcher(name) {
+        // TODO: Uncomment warnings in next minor release
+        // if ('production' !== process.env.NODE_ENV) {
+        //     console.warn('Fetcher.getFetcher is deprecated. ' +
+        //         'Please use Fetcher.getService instead.');
+        // }
+        return Fetcher.getService(name);
+    }
 
-/**
+    /**
+     * Retrieve a data service by name
+     * @method getService
+     * @memberof Fetcher
+     * @param {String} name of service
+     * @returns {Function} service
+     */
+    static getService(name) {
+        //Access service by name
+        const service = Fetcher.isRegistered(name);
+        if (!service) {
+            throw new Error(
+                `Service "${sanitizeResourceName(name)}" could not be found`
+            );
+        }
+        return service;
+    }
+
+    /**
+     * Returns true if service with name has been registered
+     * @method isRegistered
+     * @memberof Fetcher
+     * @param {String} name of service
+     * @returns {Boolean} true if service with name was registered
+     */
+    static isRegistered(name) {
+        return name && Fetcher.services[name.split('.')[0]];
+    }
+
+    /**
  * Returns express/connect middleware for Fetcher
  * @method middleware
  * @memberof Fetcher
@@ -378,305 +379,322 @@ Fetcher.isRegistered = function (name) {
  *     @param {Object} res
  *     @param {Object} next
  */
-Fetcher.middleware = function (options = {}) {
-    const responseFormatter =
-        options.responseFormatter || ((req, res, data) => data);
+    static middleware(options = {}) {
+        const responseFormatter =
+            options.responseFormatter || ((req, res, data) => data);
 
-    if (
-        Fetcher._deprecatedServicesDefinitions.length &&
-        'production' !== process.env.NODE_ENV
-    ) {
-        const deprecatedServices = Fetcher._deprecatedServicesDefinitions
-            .sort()
-            .join(', ');
+        if (
+            Fetcher._deprecatedServicesDefinitions.length &&
+            'production' !== process.env.NODE_ENV
+        ) {
+            const deprecatedServices = Fetcher._deprecatedServicesDefinitions
+                .sort()
+                .join(', ');
 
-        console.warn(`You have registered services using a deprecated property.
+            console.warn(`You have registered services using a deprecated property.
 Please, rename the property "name" to "resource" in the
 following services definitions: ${deprecatedServices}.`);
-    }
-
-    return (req, res, next) => {
-        const serviceMeta = [];
-
-        if (req.method === GET) {
-            const path = req.path.substr(1).split(';');
-            const resource = path.shift();
-
-            if (!resource) {
-                const error = fumble.http.badRequest('No resource specified', {
-                    debug: 'Bad resource',
-                });
-                error.source = 'fetchr';
-                return next(error);
-            }
-
-            if (!Fetcher.isRegistered(resource)) {
-                const resourceName = sanitizeResourceName(resource);
-                const errorMsg = `Resource "${resourceName}" is not registered`;
-                const error = fumble.http.badRequest(errorMsg, {
-                    debug: `Bad resource ${resourceName}`,
-                });
-                error.source = 'fetchr';
-                return next(error);
-            }
-
-            new Request(OP_READ, resource, {
-                req,
-                serviceMeta,
-                statsCollector: options.statsCollector,
-                paramsProcessor: options.paramsProcessor,
-            })
-                .params(parseParamValues(qs.parse(path.join('&'))))
-                .end((err, data) => {
-                    const meta = serviceMeta[0] || {};
-
-                    if (meta.headers) {
-                        res.set(meta.headers);
-                    }
-
-                    if (err) {
-                        const { statusCode, output } = getErrorResponse(err);
-                        res.status(statusCode).json(
-                            responseFormatter(req, res, { output, meta })
-                        );
-                    } else {
-                        res.status(meta.statusCode || 200).json(
-                            responseFormatter(req, res, { data, meta })
-                        );
-                    }
-                });
-        } else {
-            const requests = req.body && req.body.requests;
-
-            if (!requests || Object.keys(requests).length === 0) {
-                const error = fumble.http.badRequest('No resource specified', {
-                    debug: 'No resources',
-                });
-                error.source = 'fetchr';
-                return next(error);
-            }
-
-            const DEFAULT_GUID = 'g0';
-            const request = requests[DEFAULT_GUID];
-
-            if (!Fetcher.isRegistered(request.resource)) {
-                const resourceName = sanitizeResourceName(request.resource);
-                const errorMsg = `Resource "${resourceName}" is not registered`;
-                const error = fumble.http.badRequest(errorMsg, {
-                    debug: `Bad resource ${resourceName}`,
-                });
-                error.source = 'fetchr';
-                return next(error);
-            }
-
-            const operation = request.operation;
-            if (
-                operation !== OP_CREATE &&
-                operation !== OP_UPDATE &&
-                operation !== OP_DELETE &&
-                operation !== OP_READ
-            ) {
-                const resourceName = sanitizeResourceName(request.resource);
-                const error = fumble.http.badRequest(
-                    `Unsupported "${resourceName}.${operation}" operation`,
-                    {
-                        debug: 'Only "create", "read", "update" or "delete" operations are allowed',
-                    }
-                );
-                error.source = 'fetchr';
-                return next(error);
-            }
-
-            new Request(operation, request.resource, {
-                req,
-                serviceMeta,
-                statsCollector: options.statsCollector,
-                paramsProcessor: options.paramsProcessor,
-            })
-                .params(request.params)
-                .body(request.body || {})
-                .end((err, data) => {
-                    const meta = serviceMeta[0] || {};
-                    if (meta.headers) {
-                        res.set(meta.headers);
-                    }
-                    if (err) {
-                        const { statusCode, output } = getErrorResponse(err);
-                        res.status(statusCode).json(
-                            responseFormatter(req, res, { output, meta })
-                        );
-                    } else {
-                        res.status(meta.statusCode || 200).json({
-                            [DEFAULT_GUID]: responseFormatter(req, res, {
-                                data,
-                                meta,
-                            }),
-                        });
-                    }
-                });
         }
-        // TODO: Batching and multi requests
-    };
-};
 
-// ------------------------------------------------------------------
-// CRUD Data Access Wrapper Methods
-// ------------------------------------------------------------------
+        return (req, res, next) => {
+            const serviceMeta = [];
 
-/**
- * read operation (read as in CRUD).
- * @method read
- * @memberof Fetcher.prototype
- * @param {String} resource  The resource name
- * @param {Object} params    The parameters identify the resource, and along with information
- *                           carried in query and matrix parameters in typical REST API
- * @param {Object} [config={}] The config object.  It can contain "config" for per-request config data.
- * @param {Fetcher~fetcherCallback} callback callback invoked when fetcher is complete.
- * @static
- */
-Fetcher.prototype.read = function (resource, params, config, callback) {
-    const request = new Request('read', resource, {
-        req: this.req,
-        serviceMeta: this._serviceMeta,
-        statsCollector: this.options.statsCollector,
-    });
-    if (1 === arguments.length) {
-        return request;
-    }
-    // TODO: Uncomment warnings in next minor release
-    // if ('production' !== process.env.NODE_ENV) {
-    //     console.warn('The recommended way to use fetcher\'s .read method is \n' +
-    //         '.read(\'' + resource + '\').params({foo:bar}).end(callback);');
-    // }
-    // TODO: Remove below this line in release after next
-    if (typeof config === 'function') {
-        callback = config;
-        config = {};
-    }
-    return request.params(params).clientConfig(config).end(callback);
-};
+            if (req.method === GET) {
+                const path = req.path.substr(1).split(';');
+                const resource = path.shift();
 
-/**
- * create operation (create as in CRUD).
- * @method create
- * @memberof Fetcher.prototype
- * @param {String} resource  The resource name
- * @param {Object} params    The parameters identify the resource, and along with information
- *                           carried in query and matrix parameters in typical REST API
- * @param {Object} body      The JSON object that contains the resource data that is being created
- * @param {Object} [config={}] The config object.  It can contain "config" for per-request config data.
- * @param {Fetcher~fetcherCallback} callback callback invoked when fetcher is complete.
- * @static
- */
-Fetcher.prototype.create = function (resource, params, body, config, callback) {
-    const request = new Request('create', resource, {
-        req: this.req,
-        serviceMeta: this._serviceMeta,
-        statsCollector: this.options.statsCollector,
-    });
-    if (1 === arguments.length) {
-        return request;
-    }
-    // TODO: Uncomment warnings in next minor release
-    // if ('production' !== process.env.NODE_ENV) {
-    //     console.warn('The recommended way to use fetcher\'s .create method is \n' +
-    //         '.create(\'' + resource + '\').params({foo:bar}).body({}).end(callback);');
-    // }
-    // TODO: Remove below this line in release after next
-    if (typeof config === 'function') {
-        callback = config;
-        config = {};
-    }
-    return request.params(params).body(body).clientConfig(config).end(callback);
-};
+                if (!resource) {
+                    const error = fumble.http.badRequest(
+                        'No resource specified',
+                        {
+                            debug: 'Bad resource',
+                        }
+                    );
+                    error.source = 'fetchr';
+                    return next(error);
+                }
 
-/**
- * update operation (update as in CRUD).
- * @method update
- * @memberof Fetcher.prototype
- * @param {String} resource  The resource name
- * @param {Object} params    The parameters identify the resource, and along with information
- *                           carried in query and matrix parameters in typical REST API
- * @param {Object} body      The JSON object that contains the resource data that is being updated
- * @param {Object} [config={}] The config object.  It can contain "config" for per-request config data.
- * @param {Fetcher~fetcherCallback} callback callback invoked when fetcher is complete.
- * @static
- */
-Fetcher.prototype.update = function (resource, params, body, config, callback) {
-    const request = new Request('update', resource, {
-        req: this.req,
-        serviceMeta: this._serviceMeta,
-        statsCollector: this.options.statsCollector,
-    });
-    if (1 === arguments.length) {
-        return request;
-    }
-    // TODO: Uncomment warnings in next minor release
-    // if ('production' !== process.env.NODE_ENV) {
-    //     console.warn('The recommended way to use fetcher\'s .update method is \n' +
-    //         '.update(\'' + resource + '\').params({foo:bar}).body({}).end(callback);');
-    // }
-    // TODO: Remove below this line in release after next
-    if (typeof config === 'function') {
-        callback = config;
-        config = {};
-    }
-    return request.params(params).body(body).clientConfig(config).end(callback);
-};
+                if (!Fetcher.isRegistered(resource)) {
+                    const resourceName = sanitizeResourceName(resource);
+                    const errorMsg = `Resource "${resourceName}" is not registered`;
+                    const error = fumble.http.badRequest(errorMsg, {
+                        debug: `Bad resource ${resourceName}`,
+                    });
+                    error.source = 'fetchr';
+                    return next(error);
+                }
 
-/**
- * delete operation (delete as in CRUD).
- * @method delete
- * @memberof Fetcher.prototype
- * @param {String} resource  The resource name
- * @param {Object} params    The parameters identify the resource, and along with information
- *                           carried in query and matrix parameters in typical REST API
- * @param {Object} [config={}] The config object.  It can contain "config" for per-request config data.
- * @param {Fetcher~fetcherCallback} callback callback invoked when fetcher is complete.
- * @static
- */
-Fetcher.prototype.delete = function (resource, params, config, callback) {
-    const request = new Request('delete', resource, {
-        req: this.req,
-        serviceMeta: this._serviceMeta,
-        statsCollector: this.options.statsCollector,
-    });
-    if (1 === arguments.length) {
-        return request;
+                new Request(OP_READ, resource, {
+                    req,
+                    serviceMeta,
+                    statsCollector: options.statsCollector,
+                    paramsProcessor: options.paramsProcessor,
+                })
+                    .params(parseParamValues(qs.parse(path.join('&'))))
+                    .end((err, data) => {
+                        const meta = serviceMeta[0] || {};
+
+                        if (meta.headers) {
+                            res.set(meta.headers);
+                        }
+
+                        if (err) {
+                            const { statusCode, output } =
+                                getErrorResponse(err);
+                            res.status(statusCode).json(
+                                responseFormatter(req, res, { output, meta })
+                            );
+                        } else {
+                            res.status(meta.statusCode || 200).json(
+                                responseFormatter(req, res, { data, meta })
+                            );
+                        }
+                    });
+            } else {
+                const requests = req.body && req.body.requests;
+
+                if (!requests || Object.keys(requests).length === 0) {
+                    const error = fumble.http.badRequest(
+                        'No resource specified',
+                        {
+                            debug: 'No resources',
+                        }
+                    );
+                    error.source = 'fetchr';
+                    return next(error);
+                }
+
+                const DEFAULT_GUID = 'g0';
+                const request = requests[DEFAULT_GUID];
+
+                if (!Fetcher.isRegistered(request.resource)) {
+                    const resourceName = sanitizeResourceName(request.resource);
+                    const errorMsg = `Resource "${resourceName}" is not registered`;
+                    const error = fumble.http.badRequest(errorMsg, {
+                        debug: `Bad resource ${resourceName}`,
+                    });
+                    error.source = 'fetchr';
+                    return next(error);
+                }
+
+                const operation = request.operation;
+                if (
+                    operation !== OP_CREATE &&
+                    operation !== OP_UPDATE &&
+                    operation !== OP_DELETE &&
+                    operation !== OP_READ
+                ) {
+                    const resourceName = sanitizeResourceName(request.resource);
+                    const error = fumble.http.badRequest(
+                        `Unsupported "${resourceName}.${operation}" operation`,
+                        {
+                            debug: 'Only "create", "read", "update" or "delete" operations are allowed',
+                        }
+                    );
+                    error.source = 'fetchr';
+                    return next(error);
+                }
+
+                new Request(operation, request.resource, {
+                    req,
+                    serviceMeta,
+                    statsCollector: options.statsCollector,
+                    paramsProcessor: options.paramsProcessor,
+                })
+                    .params(request.params)
+                    .body(request.body || {})
+                    .end((err, data) => {
+                        const meta = serviceMeta[0] || {};
+                        if (meta.headers) {
+                            res.set(meta.headers);
+                        }
+                        if (err) {
+                            const { statusCode, output } =
+                                getErrorResponse(err);
+                            res.status(statusCode).json(
+                                responseFormatter(req, res, { output, meta })
+                            );
+                        } else {
+                            res.status(meta.statusCode || 200).json({
+                                [DEFAULT_GUID]: responseFormatter(req, res, {
+                                    data,
+                                    meta,
+                                }),
+                            });
+                        }
+                    });
+            }
+            // TODO: Batching and multi requests
+        };
     }
 
-    // TODO: Uncomment warnings in next minor release
-    // if ('production' !== process.env.NODE_ENV) {
-    //     console.warn('The recommended way to use fetcher\'s .read method is \n' +
-    //         '.read(\'' + resource + '\').params({foo:bar}).end(callback);');
-    // }
-    // TODO: Remove below this line in release after next
-    if (typeof config === 'function') {
-        callback = config;
-        config = {};
+    // ------------------------------------------------------------------
+    // CRUD Data Access Wrapper Methods
+    // ------------------------------------------------------------------
+
+    /**
+     * read operation (read as in CRUD).
+     * @method read
+     * @memberof Fetcher.prototype
+     * @param {String} resource  The resource name
+     * @param {Object} params    The parameters identify the resource, and along with information
+     *                           carried in query and matrix parameters in typical REST API
+     * @param {Object} [config={}] The config object.  It can contain "config" for per-request config data.
+     * @param {Fetcher~fetcherCallback} callback callback invoked when fetcher is complete.
+     * @static
+     */
+    read(resource, params, config, callback) {
+        const request = new Request('read', resource, {
+            req: this.req,
+            serviceMeta: this._serviceMeta,
+            statsCollector: this.options.statsCollector,
+        });
+        if (1 === arguments.length) {
+            return request;
+        }
+        // TODO: Uncomment warnings in next minor release
+        // if ('production' !== process.env.NODE_ENV) {
+        //     console.warn('The recommended way to use fetcher\'s .read method is \n' +
+        //         '.read(\'' + resource + '\').params({foo:bar}).end(callback);');
+        // }
+        // TODO: Remove below this line in release after next
+        if (typeof config === 'function') {
+            callback = config;
+            config = {};
+        }
+        return request.params(params).clientConfig(config).end(callback);
     }
-    return request.params(params).clientConfig(config).end(callback);
-};
 
-/**
- * update fetchr options
- * @method updateOptions
- * @memberof Fetcher.prototype
- * @param {Object} options configuration options for Fetcher
- * @param {Object} [options.req] The request object.  It can contain per-request/context data.
- * @param {string} [options.xhrPath="/api"] The path for XHR requests. Will be ignored server side.
- */
-Fetcher.prototype.updateOptions = function (options) {
-    this.options = Object.assign(this.options, options);
-    this.req = this.options.req || {};
-};
+    /**
+     * create operation (create as in CRUD).
+     * @method create
+     * @memberof Fetcher.prototype
+     * @param {String} resource  The resource name
+     * @param {Object} params    The parameters identify the resource, and along with information
+     *                           carried in query and matrix parameters in typical REST API
+     * @param {Object} body      The JSON object that contains the resource data that is being created
+     * @param {Object} [config={}] The config object.  It can contain "config" for per-request config data.
+     * @param {Fetcher~fetcherCallback} callback callback invoked when fetcher is complete.
+     * @static
+     */
+    create(resource, params, body, config, callback) {
+        const request = new Request('create', resource, {
+            req: this.req,
+            serviceMeta: this._serviceMeta,
+            statsCollector: this.options.statsCollector,
+        });
+        if (1 === arguments.length) {
+            return request;
+        }
+        // TODO: Uncomment warnings in next minor release
+        // if ('production' !== process.env.NODE_ENV) {
+        //     console.warn('The recommended way to use fetcher\'s .create method is \n' +
+        //         '.create(\'' + resource + '\').params({foo:bar}).body({}).end(callback);');
+        // }
+        // TODO: Remove below this line in release after next
+        if (typeof config === 'function') {
+            callback = config;
+            config = {};
+        }
+        return request
+            .params(params)
+            .body(body)
+            .clientConfig(config)
+            .end(callback);
+    }
 
-/**
- * Get all the aggregated metadata sent data services in this request
- */
-Fetcher.prototype.getServiceMeta = function () {
-    return this._serviceMeta;
-};
+    /**
+     * update operation (update as in CRUD).
+     * @method update
+     * @memberof Fetcher.prototype
+     * @param {String} resource  The resource name
+     * @param {Object} params    The parameters identify the resource, and along with information
+     *                           carried in query and matrix parameters in typical REST API
+     * @param {Object} body      The JSON object that contains the resource data that is being updated
+     * @param {Object} [config={}] The config object.  It can contain "config" for per-request config data.
+     * @param {Fetcher~fetcherCallback} callback callback invoked when fetcher is complete.
+     * @static
+     */
+    update(resource, params, body, config, callback) {
+        const request = new Request('update', resource, {
+            req: this.req,
+            serviceMeta: this._serviceMeta,
+            statsCollector: this.options.statsCollector,
+        });
+        if (1 === arguments.length) {
+            return request;
+        }
+        // TODO: Uncomment warnings in next minor release
+        // if ('production' !== process.env.NODE_ENV) {
+        //     console.warn('The recommended way to use fetcher\'s .update method is \n' +
+        //         '.update(\'' + resource + '\').params({foo:bar}).body({}).end(callback);');
+        // }
+        // TODO: Remove below this line in release after next
+        if (typeof config === 'function') {
+            callback = config;
+            config = {};
+        }
+        return request
+            .params(params)
+            .body(body)
+            .clientConfig(config)
+            .end(callback);
+    }
+
+    /**
+     * delete operation (delete as in CRUD).
+     * @method delete
+     * @memberof Fetcher.prototype
+     * @param {String} resource  The resource name
+     * @param {Object} params    The parameters identify the resource, and along with information
+     *                           carried in query and matrix parameters in typical REST API
+     * @param {Object} [config={}] The config object.  It can contain "config" for per-request config data.
+     * @param {Fetcher~fetcherCallback} callback callback invoked when fetcher is complete.
+     * @static
+     */
+    delete(resource, params, config, callback) {
+        const request = new Request('delete', resource, {
+            req: this.req,
+            serviceMeta: this._serviceMeta,
+            statsCollector: this.options.statsCollector,
+        });
+        if (1 === arguments.length) {
+            return request;
+        }
+
+        // TODO: Uncomment warnings in next minor release
+        // if ('production' !== process.env.NODE_ENV) {
+        //     console.warn('The recommended way to use fetcher\'s .read method is \n' +
+        //         '.read(\'' + resource + '\').params({foo:bar}).end(callback);');
+        // }
+        // TODO: Remove below this line in release after next
+        if (typeof config === 'function') {
+            callback = config;
+            config = {};
+        }
+        return request.params(params).clientConfig(config).end(callback);
+    }
+
+    /**
+     * update fetchr options
+     * @method updateOptions
+     * @memberof Fetcher.prototype
+     * @param {Object} options configuration options for Fetcher
+     * @param {Object} [options.req] The request object.  It can contain per-request/context data.
+     * @param {string} [options.xhrPath="/api"] The path for XHR requests. Will be ignored server side.
+     */
+    updateOptions(options) {
+        this.options = Object.assign(this.options, options);
+        this.req = this.options.req || {};
+    }
+
+    /**
+     * Get all the aggregated metadata sent data services in this request
+     */
+    getServiceMeta() {
+        return this._serviceMeta;
+    }
+}
 
 module.exports = Fetcher;
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fetchr",
   "version": "0.7.1",
   "description": "Fetchr augments Flux applications by allowing Flux stores to be used on server and client to fetch data",
-  "main": "index.js",
+  "main": "./libs/fetcher.js",
   "browser": "./libs/fetcher.client.js",
   "scripts": {
     "format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "lint": "eslint . && npm run format:check",
+    "lint": "npm run lint:client && npm run lint:server && npm run format:check",
+    "lint:client": "eslint libs/util/ libs/fetcher.client.js",
+    "lint:server": "eslint --parser-options=ecmaVersion:latest libs/fetcher.js",
     "test": "npm run test:unit && npm run test:functional",
     "test:coverage": "nyc --reporter=lcov npm run test:unit",
     "test:unit": "NODE_ENV=test mocha tests/unit/ --recursive --reporter spec --timeout 20000 --exit --require tests/unit/setup.js",


### PR DESCRIPTION
This changes should even work with the already unsupported Node 10 (the functional tests pass, but unit don't since we already use some modern APIs there).

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
