### PR TITLE
refactor: remove unused batching code and remove duplication

### DIFF
--- a/libs/fetcher.client.js
+++ b/libs/fetcher.client.js
@@ -17,10 +17,6 @@ var OP_READ = 'read';
 var defaultConstructGetUri = require('./util/defaultConstructGetUri');
 var forEach = require('./util/forEach');
 
-function isFunction(value) {
-    return typeof value === 'function';
-}
-
 function parseResponse(response) {
     if (response && response.responseText) {
         try {
@@ -248,9 +244,10 @@ function executeRequest(request, resolve, reject) {
     }
 
     if (request.operation === OP_READ) {
-        var buildGetUrl = isFunction(config.constructGetUri)
-            ? config.constructGetUri
-            : defaultConstructGetUri;
+        var buildGetUrl =
+            typeof config.constructGetUri === 'function'
+                ? config.constructGetUri
+                : defaultConstructGetUri;
 
         var context = pickContext(
             request.options.context,

--- a/libs/fetcher.client.js
+++ b/libs/fetcher.client.js
@@ -10,7 +10,6 @@
  * @module Fetcher
  */
 var REST = require('./util/http.client');
-var DEFAULT_GUID = 'g0';
 var DEFAULT_PATH = '/api';
 var DEFAULT_TIMEOUT = 3000;
 var MAX_URI_LEN = 2048;
@@ -228,7 +227,6 @@ function executeRequest(request, resolve, reject) {
     var use_post;
     var allow_retry_post;
     var uri = clientConfig.uri;
-    var requests;
     var data;
 
     if (!uri) {
@@ -295,20 +293,16 @@ function executeRequest(request, resolve, reject) {
         );
     }
 
-    // individual request is also normalized into a request hash to pass to api
-    requests = {};
-    requests[DEFAULT_GUID] = {
+    data = {
         resource: request.resource,
         operation: request.operation,
         params: request._params,
+        context: request.options.context,
     };
     if (request._body) {
-        requests[DEFAULT_GUID].body = request._body;
+        data.body = request._body;
     }
-    data = {
-        requests: requests,
-        context: request.options.context,
-    }; // TODO: remove. leave here for now for backward compatibility
+
     uri = request._constructPostUri(uri);
     allow_retry_post = request.operation === OP_READ;
     return REST.post(
@@ -326,13 +320,7 @@ function executeRequest(request, resolve, reject) {
             if (err) {
                 return reject(err);
             }
-            var result = parseResponse(response);
-            if (result) {
-                result = result[DEFAULT_GUID] || {};
-            } else {
-                result = {};
-            }
-            resolve(result);
+            resolve(parseResponse(response));
         }
     );
 }

--- a/libs/fetcher.client.js
+++ b/libs/fetcher.client.js
@@ -10,12 +10,14 @@
  * @module Fetcher
  */
 var REST = require('./util/http.client');
+var defaultConstructGetUri = require('./util/defaultConstructGetUri');
+var forEach = require('./util/forEach');
+var pickContext = require('./util/pickContext');
+
 var DEFAULT_PATH = '/api';
 var DEFAULT_TIMEOUT = 3000;
 var MAX_URI_LEN = 2048;
 var OP_READ = 'read';
-var defaultConstructGetUri = require('./util/defaultConstructGetUri');
-var forEach = require('./util/forEach');
 
 function parseResponse(response) {
     if (response && response.responseText) {
@@ -26,43 +28,6 @@ function parseResponse(response) {
         }
     }
     return null;
-}
-
-/**
- * Pick keys from the context object
- * @method pickContext
- * @param {Object} context - context object
- * @param {Function|Array|String} picker - key, array of keys or
- * function that return keys to be extracted from context.
- * @param {String} method - method name, GET or POST
- */
-function pickContext(context, picker, method) {
-    if (!picker || !picker[method]) {
-        return context;
-    }
-
-    var p = picker[method];
-    var result = {};
-
-    if (typeof p === 'string') {
-        result[p] = context[p];
-    } else if (Array.isArray(p)) {
-        p.forEach(function (key) {
-            result[key] = context[key];
-        });
-    } else if (typeof p === 'function') {
-        forEach(context, function (value, key) {
-            if (p(value, key, context)) {
-                result[key] = context[key];
-            }
-        });
-    } else {
-        throw new TypeError(
-            'picker must be an string, an array, or a function.'
-        );
-    }
-
-    return result;
 }
 
 /**

--- a/libs/fetcher.client.js
+++ b/libs/fetcher.client.js
@@ -19,17 +19,6 @@ var DEFAULT_TIMEOUT = 3000;
 var MAX_URI_LEN = 2048;
 var OP_READ = 'read';
 
-function parseResponse(response) {
-    if (response && response.responseText) {
-        try {
-            return JSON.parse(response.responseText);
-        } catch (e) {
-            return null;
-        }
-    }
-    return null;
-}
-
 /**
  * A RequestClient instance represents a single fetcher request.
  * The constructor requires `operation` (CRUD) and `resource`.
@@ -188,7 +177,7 @@ function executeRequest(request, resolve, reject) {
         if (err) {
             return reject(err);
         }
-        resolve(parseResponse(response));
+        resolve(response);
     };
 
     var config = Object.assign(

--- a/libs/fetcher.js
+++ b/libs/fetcher.js
@@ -447,9 +447,9 @@ following services definitions: ${deprecatedServices}.`);
                         }
                     });
             } else {
-                const requests = req.body && req.body.requests;
+                const request = req.body || {};
 
-                if (!requests || Object.keys(requests).length === 0) {
+                if (!request.resource) {
                     const error = fumble.http.badRequest(
                         'No resource specified',
                         {
@@ -459,9 +459,6 @@ following services definitions: ${deprecatedServices}.`);
                     error.source = 'fetchr';
                     return next(error);
                 }
-
-                const DEFAULT_GUID = 'g0';
-                const request = requests[DEFAULT_GUID];
 
                 if (!Fetcher.isRegistered(request.resource)) {
                     const resourceName = sanitizeResourceName(request.resource);
@@ -511,16 +508,12 @@ following services definitions: ${deprecatedServices}.`);
                                 responseFormatter(req, res, { output, meta })
                             );
                         } else {
-                            res.status(meta.statusCode || 200).json({
-                                [DEFAULT_GUID]: responseFormatter(req, res, {
-                                    data,
-                                    meta,
-                                }),
-                            });
+                            res.status(meta.statusCode || 200).json(
+                                responseFormatter(req, res, { data, meta })
+                            );
                         }
                     });
             }
-            // TODO: Batching and multi requests
         };
     }
 

--- a/libs/util/http.client.js
+++ b/libs/util/http.client.js
@@ -26,6 +26,17 @@ var DEFAULT_CONFIG = {
 
 var INITIAL_ATTEMPT = 0;
 
+function parseResponse(response) {
+    if (response && response.responseText) {
+        try {
+            return JSON.parse(response.responseText);
+        } catch (e) {
+            return null;
+        }
+    }
+    return null;
+}
+
 function normalizeHeaders(rawHeaders, method, isCors) {
     var headers = Object.assign({}, rawHeaders);
 
@@ -113,7 +124,7 @@ function doRequest(method, url, headers, data, config, attempt, callback) {
         withCredentials: config.withCredentials,
         on: {
             success: function (err, response) {
-                callback(null, response);
+                callback(null, parseResponse(response));
             },
             failure: function (err, response) {
                 if (!shouldRetry(method, config, response.status, attempt)) {

--- a/libs/util/pickContext.js
+++ b/libs/util/pickContext.js
@@ -1,0 +1,40 @@
+var forEach = require('./forEach');
+
+/**
+ * Pick keys from the context object
+ * @method pickContext
+ * @param {Object} context - context object
+ * @param {Function|Array|String} picker - key, array of keys or
+ * function that return keys to be extracted from context.
+ * @param {String} method - method name, GET or POST
+ */
+function pickContext(context, picker, method) {
+    if (!picker || !picker[method]) {
+        return context;
+    }
+
+    var p = picker[method];
+    var result = {};
+
+    if (typeof p === 'string') {
+        result[p] = context[p];
+    } else if (Array.isArray(p)) {
+        p.forEach(function (key) {
+            result[key] = context[key];
+        });
+    } else if (typeof p === 'function') {
+        forEach(context, function (value, key) {
+            if (p(value, key, context)) {
+                result[key] = context[key];
+            }
+        });
+    } else {
+        throw new TypeError(
+            'picker must be an string, an array, or a function.'
+        );
+    }
+
+    return result;
+}
+
+module.exports = pickContext;

--- a/tests/unit/libs/fetcher.js
+++ b/tests/unit/libs/fetcher.js
@@ -863,7 +863,7 @@ describe('Server Fetcher', function () {
                 var request = { method: 'GET', path: '/' };
                 var error = {
                     message: 'No resource specified',
-                    debug: 'Bad resource',
+                    debug: 'No resource',
                 };
                 makeInvalidReqTest(request, error, done);
             });
@@ -934,7 +934,7 @@ describe('Server Fetcher', function () {
                 var request = { method: 'POST', body: { requests: {} } };
                 var error = {
                     message: 'No resource specified',
-                    debug: 'No resources',
+                    debug: 'No resource',
                 };
                 makeInvalidReqTest(request, error, done);
             });
@@ -943,7 +943,7 @@ describe('Server Fetcher', function () {
                 var request = { method: 'POST' };
                 var error = {
                     message: 'No resource specified',
-                    debug: 'No resources',
+                    debug: 'No resource',
                 };
                 makeInvalidReqTest(request, error, done);
             });

--- a/tests/unit/libs/fetcher.js
+++ b/tests/unit/libs/fetcher.js
@@ -126,18 +126,14 @@ describe('Server Fetcher', function () {
                         method: 'POST',
                         path: '/' + mockService.resource,
                         body: {
-                            requests: {
-                                g0: {
-                                    resource: mockService.resource,
-                                    operation: operation,
-                                    params: {
-                                        uuids: [
-                                            'cd7240d6-aeed-3fed-b63c-d7e99e21ca17',
-                                            'cd7240d6-aeed-3fed-b63c-d7e99e21ca17',
-                                        ],
-                                        id: 'asdf',
-                                    },
-                                },
+                            resource: mockService.resource,
+                            operation: operation,
+                            params: {
+                                uuids: [
+                                    'cd7240d6-aeed-3fed-b63c-d7e99e21ca17',
+                                    'cd7240d6-aeed-3fed-b63c-d7e99e21ca17',
+                                ],
+                                id: 'asdf',
                             },
                             context: {
                                 site: '',
@@ -149,22 +145,18 @@ describe('Server Fetcher', function () {
                         json: function (response) {
                             expect(response).to.exist;
                             expect(response).to.not.be.empty;
-                            var data = response.g0.data;
+                            var data = response.data;
                             expect(data).to.contain.keys('operation', 'args');
                             expect(data.operation.name).to.equal(operation);
                             expect(data.operation.success).to.be.true;
                             expect(data.args).to.contain.keys('params');
-                            expect(data.args.params).to.equal(
-                                req.body.requests.g0.params
-                            );
+                            expect(data.args.params).to.equal(req.body.params);
                             expect(statusCodeSet).to.be.true;
                             expect(stats.resource).to.eql(mockService.resource);
                             expect(stats.operation).to.eql(operation);
                             expect(stats.statusCode).to.eql(200);
                             expect(stats.time).to.be.at.least(0);
-                            expect(stats.params).to.eql(
-                                req.body.requests.g0.params
-                            );
+                            expect(stats.params).to.eql(req.body.params);
                             done();
                         },
                         status: function (code) {
@@ -199,18 +191,14 @@ describe('Server Fetcher', function () {
                         method: 'POST',
                         path: '/' + mockService.resource,
                         body: {
-                            requests: {
-                                g0: {
-                                    resource: mockService.resource,
-                                    operation: operation,
-                                    params: {
-                                        uuids: [
-                                            'cd7240d6-aeed-3fed-b63c-d7e99e21ca17',
-                                            'cd7240d6-aeed-3fed-b63c-d7e99e21ca17',
-                                        ],
-                                        id: 'asdf',
-                                    },
-                                },
+                            resource: mockService.resource,
+                            operation: operation,
+                            params: {
+                                uuids: [
+                                    'cd7240d6-aeed-3fed-b63c-d7e99e21ca17',
+                                    'cd7240d6-aeed-3fed-b63c-d7e99e21ca17',
+                                ],
+                                id: 'asdf',
                             },
                             context: {
                                 site: '',
@@ -222,23 +210,19 @@ describe('Server Fetcher', function () {
                         json: function (response) {
                             expect(response).to.exist;
                             expect(response).to.not.be.empty;
-                            var data = response.g0.data;
+                            var data = response.data;
                             expect(data).to.contain.keys('operation', 'args');
                             expect(data.operation.name).to.equal(operation);
                             expect(data.operation.success).to.be.true;
                             expect(data.args).to.contain.keys('params');
-                            expect(data.args.params).to.equal(
-                                req.body.requests.g0.params
-                            );
+                            expect(data.args.params).to.equal(req.body.params);
                             expect(headersSet).to.eql(responseHeaders);
                             expect(statusCodeSet).to.be.true;
                             expect(stats.resource).to.eql(mockService.resource);
                             expect(stats.operation).to.eql(operation);
                             expect(stats.statusCode).to.eql(201);
                             expect(stats.time).to.be.at.least(0);
-                            expect(stats.params).to.eql(
-                                req.body.requests.g0.params
-                            );
+                            expect(stats.params).to.eql(req.body.params);
                             expect(stats.err).to.eql(null);
                             done();
                         },
@@ -286,13 +270,9 @@ describe('Server Fetcher', function () {
                             method: 'POST',
                             path: '/' + mockErrorService.resource,
                             body: {
-                                requests: {
-                                    g0: {
-                                        resource: mockErrorService.resource,
-                                        operation: operation,
-                                        params: params,
-                                    },
-                                },
+                                resource: mockErrorService.resource,
+                                operation: operation,
+                                params: params,
                                 context: {
                                     site: '',
                                     device: '',
@@ -910,11 +890,7 @@ describe('Server Fetcher', function () {
                 var request = {
                     method: 'POST',
                     body: {
-                        requests: {
-                            g0: {
-                                resource: 'invalidService',
-                            },
-                        },
+                        resource: 'invalidService',
                     },
                 };
                 var error = {
@@ -928,11 +904,7 @@ describe('Server Fetcher', function () {
                 var request = {
                     method: 'POST',
                     body: {
-                        requests: {
-                            g0: {
-                                resource: 'invalid&Service',
-                            },
-                        },
+                        resource: 'invalid&Service',
                     },
                 };
                 var error = {
@@ -946,12 +918,8 @@ describe('Server Fetcher', function () {
                 var request = {
                     method: 'POST',
                     body: {
-                        requests: {
-                            g0: {
-                                resource: mockErrorService.resource,
-                                operation: 'constructor',
-                            },
-                        },
+                        resource: mockErrorService.resource,
+                        operation: 'constructor',
                     },
                 };
                 var error = {
@@ -1061,18 +1029,14 @@ describe('Server Fetcher', function () {
                             method: 'POST',
                             path: '/' + mockService.resource,
                             body: {
-                                requests: {
-                                    g0: {
-                                        resource: mockService.resource,
-                                        operation: operation,
-                                        params: {
-                                            uuids: [
-                                                'cd7240d6-aeed-3fed-b63c-d7e99e21ca17',
-                                                'cd7240d6-aeed-3fed-b63c-d7e99e21ca17',
-                                            ],
-                                            id: 'asdf',
-                                        },
-                                    },
+                                resource: mockService.resource,
+                                operation: operation,
+                                params: {
+                                    uuids: [
+                                        'cd7240d6-aeed-3fed-b63c-d7e99e21ca17',
+                                        'cd7240d6-aeed-3fed-b63c-d7e99e21ca17',
+                                    ],
+                                    id: 'asdf',
                                 },
                                 context: {
                                     site: '',
@@ -1084,12 +1048,12 @@ describe('Server Fetcher', function () {
                             json: function (response) {
                                 expect(response).to.exist;
                                 expect(response).to.not.be.empty;
-                                expect(response.g0).to.contain.keys(
+                                expect(response).to.contain.keys(
                                     'data',
                                     'meta',
                                     'modified'
                                 );
-                                var data = response.g0.data;
+                                var data = response.data;
                                 expect(data).to.contain.keys(
                                     'operation',
                                     'args'
@@ -1098,7 +1062,7 @@ describe('Server Fetcher', function () {
                                 expect(data.operation.success).to.be.true;
                                 expect(data.args).to.contain.keys('params');
                                 expect(data.args.params).to.equal(
-                                    req.body.requests.g0.params
+                                    req.body.params
                                 );
                                 expect(statusCodeSet).to.be.true;
                                 done();
@@ -1215,18 +1179,14 @@ describe('Server Fetcher', function () {
                     ';' +
                     qs.stringify(params, ';'),
                 body: {
-                    requests: {
-                        g0: {
-                            resource: mockService.resource,
-                            operation: operation,
-                            params: {
-                                uuids: [
-                                    'cd7240d6-aeed-3fed-b63c-d7e99e21ca17',
-                                    'cd7240d6-aeed-3fed-b63c-d7e99e21ca17',
-                                ],
-                                id: 'asdf',
-                            },
-                        },
+                    resource: mockService.resource,
+                    operation: operation,
+                    params: {
+                        uuids: [
+                            'cd7240d6-aeed-3fed-b63c-d7e99e21ca17',
+                            'cd7240d6-aeed-3fed-b63c-d7e99e21ca17',
+                        ],
+                        id: 'asdf',
                     },
                     context: {
                         site: '',
@@ -1238,15 +1198,13 @@ describe('Server Fetcher', function () {
                 json: function (response) {
                     expect(response).to.exist;
                     expect(response).to.not.be.empty;
-                    expect(response.g0).to.contain.keys('data', 'meta');
-                    var data = response.g0.data;
+                    expect(response).to.contain.keys('data', 'meta');
+                    var data = response.data;
                     expect(data).to.contain.keys('operation', 'args');
                     expect(data.operation.name).to.equal(operation);
                     expect(data.operation.success).to.be.true;
                     expect(data.args).to.contain.keys('params');
-                    expect(data.args.params).to.include(
-                        req.body.requests.g0.params
-                    );
+                    expect(data.args.params).to.include(req.body.params);
                     expect(data.args.params.newParam).to.include('YES!');
                     expect(statusCodeSet).to.be.true;
                     done();

--- a/tests/unit/libs/util/http.client.js
+++ b/tests/unit/libs/util/http.client.js
@@ -26,7 +26,7 @@ describe('Client HTTP', function () {
     describe('#Successful requests', function () {
         beforeEach(function () {
             responseStatus = 200;
-            mockBody = 'BODY';
+            mockBody = { data: 'BODY' };
         });
 
         it('GET', function (done) {
@@ -45,8 +45,7 @@ describe('Client HTTP', function () {
                 expect(options.headers.get('X-Foo')).to.equal('foo');
                 expect(options.method).to.equal('GET');
                 expect(err).to.equal(null);
-                expect(response.statusCode).to.equal(200);
-                expect(response.responseText).to.equal('BODY');
+                expect(response).to.deep.equal(mockBody);
                 done();
             });
         });
@@ -81,7 +80,7 @@ describe('Client HTTP', function () {
     describe('#Successful CORS requests', function () {
         beforeEach(function () {
             responseStatus = 200;
-            mockBody = 'BODY';
+            mockBody = { data: 'BODY' };
             sinon.spy(global, 'Request');
         });
 
@@ -109,8 +108,7 @@ describe('Client HTTP', function () {
                     expect(options.headers.get('X-Foo')).to.equal('foo');
                     expect(options.method).to.equal('GET');
                     expect(err).to.equal(null);
-                    expect(response.statusCode).to.equal(200);
-                    expect(response.responseText).to.equal('BODY');
+                    expect(response).to.deep.equal(mockBody);
 
                     sinon.assert.calledWith(
                         Request,


### PR DESCRIPTION
Support for batched requests was drop a long time ago (see: https://github.com/yahoo/fetchr/pull/110) but we still have some code from that time.

By removing it completely, GET and POST requests are almost identical (the only difference is that POST has a body). This allows us to do some refactoring to remove many code duplication.

The change is quite big (and is on top of #342, so I recommend to merge that one first) but hopefully, reviewing commit by commit should make it easier to review.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
