### PR TITLE
refactor(http): remove callbacks, simplify options normalization and export only one function

### DIFF
--- a/libs/util/http.client.js
+++ b/libs/util/http.client.js
@@ -247,6 +247,8 @@ function io(options) {
  * @class REST.HTTP
  */
 module.exports = {
+    default: doRequest,
+
     /**
      * @method get
      * @public

--- a/libs/util/http.client.js
+++ b/libs/util/http.client.js
@@ -7,21 +7,59 @@
  * @module rest-http
  */
 
-/*
- * Default configurations:
- *   timeout: timeout (in ms) for each request
- *   retry: retry related settings, such as retry interval amount (in ms), max_retries.
- *          Note that only retry only applies on GET.
- */
-var DEFAULT_CONFIG = {
-        retry: {
-            interval: 200,
-            maxRetries: 0,
-            statusCodes: [0, 408, 999],
-        },
-        unsafeAllowRetry: false,
-    },
-    METHOD_POST = 'POST';
+function normalizeHeaders(options) {
+    var headers = Object.assign({}, options.headers);
+
+    if (!options.config.cors) {
+        headers['X-Requested-With'] = 'XMLHttpRequest';
+    }
+
+    if (options.method === 'POST') {
+        headers['Content-Type'] = 'application/json';
+    }
+
+    return headers;
+}
+
+function normalizeRetry(options) {
+    var retry = {
+        interval: 200,
+        maxRetries: 0,
+        retryOnPost: false,
+        statusCodes: [0, 408, 999],
+    };
+
+    if (!options.config.retry) {
+        return retry;
+    }
+
+    if (options.config.unsafeAllowRetry) {
+        retry.retryOnPost = true;
+    }
+
+    Object.assign(retry, options.config.retry);
+
+    if (retry.max_retries) {
+        console.warn(
+            '"max_retries" is deprecated and will be removed in a future release, use "maxRetries" instead.'
+        );
+        retry.maxRetries = retry.max_retries;
+    }
+
+    return retry;
+}
+
+function normalizeOptions(options) {
+    return {
+        credentials: options.config.withCredentials ? 'include' : 'same-origin',
+        body: options.data != null ? JSON.stringify(options.data) : undefined,
+        headers: normalizeHeaders(options),
+        method: options.method,
+        retry: normalizeRetry(options),
+        timeout: options.config.timeout || options.config.xhrTimeout,
+        url: options.url,
+    };
+}
 
 function parseResponse(response) {
     if (response) {
@@ -34,80 +72,16 @@ function parseResponse(response) {
     return null;
 }
 
-function normalizeHeaders(rawHeaders, method, isCors) {
-    var headers = Object.assign({}, rawHeaders);
-
-    if (!isCors) {
-        headers['X-Requested-With'] = 'XMLHttpRequest';
-    }
-
-    if (method === METHOD_POST) {
-        headers['Content-Type'] = 'application/json';
-    }
-
-    return headers;
-}
-
-function shouldRetry(method, config, statusCode, attempt) {
-    if (attempt >= config.retry.maxRetries) {
+function shouldRetry(options, statusCode, attempt) {
+    if (attempt >= options.retry.maxRetries) {
         return false;
     }
 
-    if (method === METHOD_POST && !config.unsafeAllowRetry) {
+    if (options.method === 'POST' && !options.retry.retryOnPost) {
         return false;
     }
 
-    return config.retry.statusCodes.indexOf(statusCode) !== -1;
-}
-
-function mergeConfig(config) {
-    var cfg = {
-        unsafeAllowRetry: config.unsafeAllowRetry || false,
-        retry: {
-            interval: DEFAULT_CONFIG.retry.interval,
-            maxRetries: DEFAULT_CONFIG.retry.maxRetries,
-            statusCodes: DEFAULT_CONFIG.retry.statusCodes,
-        },
-    };
-
-    if (config) {
-        var timeout = config.timeout || config.xhrTimeout;
-        timeout = parseInt(timeout, 10);
-        if (!isNaN(timeout) && timeout > 0) {
-            cfg.timeout = timeout;
-        }
-
-        if (config.retry) {
-            var interval = parseInt(config.retry.interval, 10);
-            if (!isNaN(interval) && interval > 0) {
-                cfg.retry.interval = interval;
-            }
-
-            if (config.retry.max_retries !== undefined) {
-                console.warn(
-                    '"max_retries" is deprecated and will be removed in a future release, use "maxRetries" instead.'
-                );
-            }
-
-            var maxRetries = parseInt(
-                config.retry.max_retries || config.retry.maxRetries,
-                10
-            );
-            if (!isNaN(maxRetries) && maxRetries >= 0) {
-                cfg.retry.maxRetries = maxRetries;
-            }
-
-            if (config.retry.statusCodes) {
-                cfg.retry.statusCodes = config.retry.statusCodes;
-            }
-        }
-
-        if (config.withCredentials) {
-            cfg.withCredentials = config.withCredentials;
-        }
-    }
-
-    return cfg;
+    return options.retry.statusCodes.indexOf(statusCode) !== -1;
 }
 
 function delayPromise(fn, delay) {
@@ -163,10 +137,10 @@ function FetchrError(options, request, response, responseBody, originalError) {
 
 function io(options) {
     var request = new Request(options.url, {
-        method: options.method,
+        body: options.body,
+        credentials: options.credentials,
         headers: options.headers,
-        body: options.data,
-        credentials: options.withCredentials ? 'include' : 'same-origin',
+        method: options.method,
         signal: options.controller.signal,
     });
 
@@ -200,28 +174,21 @@ function io(options) {
     );
 }
 
-function httpRequest(options, attempt) {
+function httpRequest(rawOptions, attempt) {
     var controller = new AbortController();
     var currentAttempt = attempt || 0;
-    var config = mergeConfig(options.config);
-    var headers = normalizeHeaders(
-        options.headers,
-        options.method,
-        config.cors
-    );
+    var options = normalizeOptions(rawOptions);
 
     var promise = io({
+        body: options.body,
         controller: controller,
-        url: options.url,
+        credentials: options.credentials,
+        headers: options.headers,
         method: options.method,
-        timeout: config.timeout,
-        headers: headers,
-        withCredentials: config.withCredentials,
-        data: options.data !== null ? JSON.stringify(options.data) : undefined,
+        timeout: options.timeout,
+        url: options.url,
     }).catch(function (err) {
-        if (
-            !shouldRetry(options.method, config, err.statusCode, currentAttempt)
-        ) {
+        if (!shouldRetry(options, err.statusCode, currentAttempt)) {
             throw err;
         }
 
@@ -229,10 +196,12 @@ function httpRequest(options, attempt) {
         // strategy published in
         // https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
         var delay =
-            Math.random() * config.retry.interval * Math.pow(2, currentAttempt);
+            Math.random() *
+            options.retry.interval *
+            Math.pow(2, currentAttempt);
 
         return delayPromise(function () {
-            return httpRequest(options, currentAttempt + 1);
+            return httpRequest(rawOptions, currentAttempt + 1);
         }, delay);
     });
 

--- a/tests/unit/libs/fetcher.client.js
+++ b/tests/unit/libs/fetcher.client.js
@@ -209,13 +209,13 @@ describe('Client Fetcher', function () {
         describe('should be configurable globally', function () {
             before(function () {
                 mockery.registerMock('./util/http.client', {
-                    get: function (url, headers, config, callback) {
+                    get: function (url, headers, config) {
                         expect(config.xhrTimeout).to.equal(4000);
-                        return REST.get(url, headers, config, callback);
+                        return REST.get(url, headers, config);
                     },
-                    post: function (url, headers, body, config, callback) {
+                    post: function (url, headers, body, config) {
                         expect(config.xhrTimeout).to.equal(4000);
-                        return REST.post(url, headers, body, config, callback);
+                        return REST.post(url, headers, body, config);
                     },
                 });
                 mockery.enable({
@@ -238,15 +238,15 @@ describe('Client Fetcher', function () {
         describe('should be configurable per each fetchr call', function () {
             before(function () {
                 mockery.registerMock('./util/http.client', {
-                    get: function (url, headers, config, callback) {
+                    get: function (url, headers, config) {
                         expect(config.xhrTimeout).to.equal(4000);
                         expect(config.timeout).to.equal(5000);
-                        return REST.get(url, headers, config, callback);
+                        return REST.get(url, headers, config);
                     },
-                    post: function (url, headers, body, config, callback) {
+                    post: function (url, headers, body, config) {
                         expect(config.xhrTimeout).to.equal(4000);
                         expect(config.timeout).to.equal(5000);
-                        return REST.post(url, headers, body, config, callback);
+                        return REST.post(url, headers, body, config);
                     },
                 });
                 mockery.enable({
@@ -279,13 +279,13 @@ describe('Client Fetcher', function () {
         describe('should default to DEFAULT_TIMEOUT of 3000', function () {
             before(function () {
                 mockery.registerMock('./util/http.client', {
-                    get: function (url, headers, config, callback) {
+                    get: function (url, headers, config) {
                         expect(config.xhrTimeout).to.equal(3000);
-                        return REST.get(url, headers, config, callback);
+                        return REST.get(url, headers, config);
                     },
-                    post: function (url, headers, body, config, callback) {
+                    post: function (url, headers, body, config) {
                         expect(config.xhrTimeout).to.equal(3000);
-                        return REST.post(url, headers, body, config, callback);
+                        return REST.post(url, headers, body, config);
                     },
                 });
                 mockery.enable({
@@ -403,13 +403,13 @@ describe('Client Fetcher', function () {
         describe('should be configurable globally', function () {
             before(function () {
                 mockery.registerMock('./util/http.client', {
-                    get: function (url, headers, config, callback) {
+                    get: function (url, headers, config) {
                         expect(headers['X-APP-VERSION']).to.equal(VERSION);
-                        return REST.get(url, headers, config, callback);
+                        return REST.get(url, headers, config);
                     },
-                    post: function (url, headers, body, config, callback) {
+                    post: function (url, headers, body, config) {
                         expect(headers['X-APP-VERSION']).to.equal(VERSION);
-                        return REST.post(url, headers, body, config, callback);
+                        return REST.post(url, headers, body, config);
                     },
                 });
                 mockery.enable({
@@ -434,13 +434,13 @@ describe('Client Fetcher', function () {
         describe('should be configurable per request', function () {
             before(function () {
                 mockery.registerMock('./util/http.client', {
-                    get: function (url, headers, config, callback) {
+                    get: function (url, headers, config) {
                         expect(headers['X-APP-VERSION']).to.equal(VERSION);
-                        return REST.get(url, headers, config, callback);
+                        return REST.get(url, headers, config);
                     },
-                    post: function (url, headers, body, config, callback) {
+                    post: function (url, headers, body, config) {
                         expect(headers['X-APP-VERSION']).to.equal(VERSION);
-                        return REST.post(url, headers, body, config, callback);
+                        return REST.post(url, headers, body, config);
                     },
                 });
                 mockery.enable({

--- a/tests/unit/libs/fetcher.client.js
+++ b/tests/unit/libs/fetcher.client.js
@@ -211,11 +211,11 @@ describe('Client Fetcher', function () {
                 mockery.registerMock('./util/http.client', {
                     get: function (url, headers, config, callback) {
                         expect(config.xhrTimeout).to.equal(4000);
-                        REST.get(url, headers, config, callback);
+                        return REST.get(url, headers, config, callback);
                     },
                     post: function (url, headers, body, config, callback) {
                         expect(config.xhrTimeout).to.equal(4000);
-                        REST.post(url, headers, body, config, callback);
+                        return REST.post(url, headers, body, config, callback);
                     },
                 });
                 mockery.enable({
@@ -241,12 +241,12 @@ describe('Client Fetcher', function () {
                     get: function (url, headers, config, callback) {
                         expect(config.xhrTimeout).to.equal(4000);
                         expect(config.timeout).to.equal(5000);
-                        REST.get(url, headers, config, callback);
+                        return REST.get(url, headers, config, callback);
                     },
                     post: function (url, headers, body, config, callback) {
                         expect(config.xhrTimeout).to.equal(4000);
                         expect(config.timeout).to.equal(5000);
-                        REST.post(url, headers, body, config, callback);
+                        return REST.post(url, headers, body, config, callback);
                     },
                 });
                 mockery.enable({
@@ -281,11 +281,11 @@ describe('Client Fetcher', function () {
                 mockery.registerMock('./util/http.client', {
                     get: function (url, headers, config, callback) {
                         expect(config.xhrTimeout).to.equal(3000);
-                        REST.get(url, headers, config, callback);
+                        return REST.get(url, headers, config, callback);
                     },
                     post: function (url, headers, body, config, callback) {
                         expect(config.xhrTimeout).to.equal(3000);
-                        REST.post(url, headers, body, config, callback);
+                        return REST.post(url, headers, body, config, callback);
                     },
                 });
                 mockery.enable({
@@ -405,11 +405,11 @@ describe('Client Fetcher', function () {
                 mockery.registerMock('./util/http.client', {
                     get: function (url, headers, config, callback) {
                         expect(headers['X-APP-VERSION']).to.equal(VERSION);
-                        REST.get(url, headers, config, callback);
+                        return REST.get(url, headers, config, callback);
                     },
                     post: function (url, headers, body, config, callback) {
                         expect(headers['X-APP-VERSION']).to.equal(VERSION);
-                        REST.post(url, headers, body, config, callback);
+                        return REST.post(url, headers, body, config, callback);
                     },
                 });
                 mockery.enable({
@@ -436,11 +436,11 @@ describe('Client Fetcher', function () {
                 mockery.registerMock('./util/http.client', {
                     get: function (url, headers, config, callback) {
                         expect(headers['X-APP-VERSION']).to.equal(VERSION);
-                        REST.get(url, headers, config, callback);
+                        return REST.get(url, headers, config, callback);
                     },
                     post: function (url, headers, body, config, callback) {
                         expect(headers['X-APP-VERSION']).to.equal(VERSION);
-                        REST.post(url, headers, body, config, callback);
+                        return REST.post(url, headers, body, config, callback);
                     },
                 });
                 mockery.enable({

--- a/tests/unit/libs/fetcher.client.js
+++ b/tests/unit/libs/fetcher.client.js
@@ -13,7 +13,7 @@ var supertest = require('supertest');
 
 var Fetcher = require('../../../libs/fetcher.client');
 var defaultConstructGetUri = require('../../../libs/util/defaultConstructGetUri');
-var REST = require('../../../libs/util/http.client');
+var httpRequest = require('../../../libs/util/http.client').default;
 var testCrud = require('../../util/testCrud');
 var defaultOptions = require('../../util/defaultOptions');
 
@@ -209,13 +209,9 @@ describe('Client Fetcher', function () {
         describe('should be configurable globally', function () {
             before(function () {
                 mockery.registerMock('./util/http.client', {
-                    get: function (url, headers, config) {
-                        expect(config.xhrTimeout).to.equal(4000);
-                        return REST.get(url, headers, config);
-                    },
-                    post: function (url, headers, body, config) {
-                        expect(config.xhrTimeout).to.equal(4000);
-                        return REST.post(url, headers, body, config);
+                    default: function (options) {
+                        expect(options.config.xhrTimeout).to.equal(4000);
+                        return httpRequest(options);
                     },
                 });
                 mockery.enable({
@@ -238,15 +234,10 @@ describe('Client Fetcher', function () {
         describe('should be configurable per each fetchr call', function () {
             before(function () {
                 mockery.registerMock('./util/http.client', {
-                    get: function (url, headers, config) {
-                        expect(config.xhrTimeout).to.equal(4000);
-                        expect(config.timeout).to.equal(5000);
-                        return REST.get(url, headers, config);
-                    },
-                    post: function (url, headers, body, config) {
-                        expect(config.xhrTimeout).to.equal(4000);
-                        expect(config.timeout).to.equal(5000);
-                        return REST.post(url, headers, body, config);
+                    default: function (options) {
+                        expect(options.config.xhrTimeout).to.equal(4000);
+                        expect(options.config.timeout).to.equal(5000);
+                        return httpRequest(options);
                     },
                 });
                 mockery.enable({
@@ -279,13 +270,9 @@ describe('Client Fetcher', function () {
         describe('should default to DEFAULT_TIMEOUT of 3000', function () {
             before(function () {
                 mockery.registerMock('./util/http.client', {
-                    get: function (url, headers, config) {
-                        expect(config.xhrTimeout).to.equal(3000);
-                        return REST.get(url, headers, config);
-                    },
-                    post: function (url, headers, body, config) {
-                        expect(config.xhrTimeout).to.equal(3000);
-                        return REST.post(url, headers, body, config);
+                    default: function (options) {
+                        expect(options.config.xhrTimeout).to.equal(3000);
+                        return httpRequest(options);
                     },
                 });
                 mockery.enable({
@@ -403,13 +390,11 @@ describe('Client Fetcher', function () {
         describe('should be configurable globally', function () {
             before(function () {
                 mockery.registerMock('./util/http.client', {
-                    get: function (url, headers, config) {
-                        expect(headers['X-APP-VERSION']).to.equal(VERSION);
-                        return REST.get(url, headers, config);
-                    },
-                    post: function (url, headers, body, config) {
-                        expect(headers['X-APP-VERSION']).to.equal(VERSION);
-                        return REST.post(url, headers, body, config);
+                    default: function (options) {
+                        expect(options.headers['X-APP-VERSION']).to.equal(
+                            VERSION
+                        );
+                        return httpRequest(options);
                     },
                 });
                 mockery.enable({
@@ -434,13 +419,11 @@ describe('Client Fetcher', function () {
         describe('should be configurable per request', function () {
             before(function () {
                 mockery.registerMock('./util/http.client', {
-                    get: function (url, headers, config) {
-                        expect(headers['X-APP-VERSION']).to.equal(VERSION);
-                        return REST.get(url, headers, config);
-                    },
-                    post: function (url, headers, body, config) {
-                        expect(headers['X-APP-VERSION']).to.equal(VERSION);
-                        return REST.post(url, headers, body, config);
+                    default: function (options) {
+                        expect(options.headers['X-APP-VERSION']).to.equal(
+                            VERSION
+                        );
+                        return httpRequest(options);
                     },
                 });
                 mockery.enable({

--- a/tests/unit/libs/util/http.client.js
+++ b/tests/unit/libs/util/http.client.js
@@ -29,13 +29,13 @@ describe('Client HTTP', function () {
             mockBody = { data: 'BODY' };
         });
 
-        it('GET', function (done) {
+        it('GET', function () {
             fetchMock.get('/url', {
                 body: mockBody,
                 status: responseStatus,
             });
 
-            http.get('/url', { 'X-Foo': 'foo' }, {}, function (err, response) {
+            return http.get('/url', { 'X-Foo': 'foo' }, {}).then((response) => {
                 expect(fetchMock.calls()).to.have.lengthOf(1);
                 const options = fetchMock.lastCall().request;
                 expect(options.url).to.equal('/url');
@@ -44,24 +44,19 @@ describe('Client HTTP', function () {
                 );
                 expect(options.headers.get('X-Foo')).to.equal('foo');
                 expect(options.method).to.equal('GET');
-                expect(err).to.equal(null);
                 expect(response).to.deep.equal(mockBody);
-                done();
             });
         });
 
-        it('POST', function (done) {
+        it('POST', function () {
             fetchMock.post('/url', {
                 body: mockBody,
                 status: responseStatus,
             });
 
-            http.post(
-                '/url',
-                { 'X-Foo': 'foo' },
-                { data: 'data' },
-                {},
-                function () {
+            return http
+                .post('/url', { 'X-Foo': 'foo' }, { data: 'data' }, {})
+                .then(() => {
                     expect(fetchMock.calls()).to.have.lengthOf(1);
                     const options = fetchMock.lastCall().request;
                     expect(options.url).to.equal('/url');
@@ -71,9 +66,7 @@ describe('Client HTTP', function () {
                     expect(options.headers.get('X-Foo')).to.equal('foo');
                     expect(options.method).to.equal('POST');
                     expect(options.body.toString()).to.eql('{"data":"data"}');
-                    done();
-                }
-            );
+                });
         });
     });
 
@@ -88,17 +81,19 @@ describe('Client HTTP', function () {
             Request.restore();
         });
 
-        it('GET', function (done) {
+        it('GET', function () {
             fetchMock.get('/url', {
                 body: mockBody,
                 status: responseStatus,
             });
 
-            http.get(
-                '/url',
-                { 'X-Foo': 'foo' },
-                { cors: true, withCredentials: true },
-                function (err, response) {
+            return http
+                .get(
+                    '/url',
+                    { 'X-Foo': 'foo' },
+                    { cors: true, withCredentials: true }
+                )
+                .then(function (response) {
                     expect(fetchMock.calls()).to.have.lengthOf(1);
                     const options = fetchMock.lastCall().request;
                     expect(options.url).to.equal('/url');
@@ -107,7 +102,6 @@ describe('Client HTTP', function () {
                     );
                     expect(options.headers.get('X-Foo')).to.equal('foo');
                     expect(options.method).to.equal('GET');
-                    expect(err).to.equal(null);
                     expect(response).to.deep.equal(mockBody);
 
                     sinon.assert.calledWith(
@@ -115,24 +109,23 @@ describe('Client HTTP', function () {
                         sinon.match.string,
                         sinon.match({ credentials: 'include' })
                     );
-
-                    done();
-                }
-            );
+                });
         });
 
-        it('POST', function (done) {
+        it('POST', function () {
             fetchMock.post('/url', {
                 body: mockBody,
                 status: responseStatus,
             });
 
-            http.post(
-                '/url',
-                { 'X-Foo': 'foo' },
-                { data: 'data' },
-                { cors: true },
-                function () {
+            return http
+                .post(
+                    '/url',
+                    { 'X-Foo': 'foo' },
+                    { data: 'data' },
+                    { cors: true }
+                )
+                .then(() => {
                     expect(fetchMock.calls()).to.have.lengthOf(1);
                     const options = fetchMock.lastCall().request;
                     expect(options.url).to.equal('/url');
@@ -148,10 +141,7 @@ describe('Client HTTP', function () {
                         sinon.match.string,
                         sinon.match({ credentials: 'same-origin' })
                     );
-
-                    done();
-                }
-            );
+                });
         });
     });
 
@@ -160,56 +150,49 @@ describe('Client HTTP', function () {
             responseStatus = 400;
         });
 
-        it('GET with empty response', function (done) {
+        it('GET with empty response', function () {
             mockBody = '';
             fetchMock.get('/url', {
                 body: mockBody,
                 status: responseStatus,
             });
 
-            http.get('/url', { 'X-Foo': 'foo' }, {}, function (err) {
-                try {
-                    expect(err.message).to.equal('');
-                    expect(err.statusCode).to.equal(400);
-                    expect(err.body).to.equal('');
-                    done();
-                } catch (e) {
-                    done(e);
-                }
+            return http.get('/url', { 'X-Foo': 'foo' }, {}).catch((err) => {
+                expect(err.message).to.equal('');
+                expect(err.statusCode).to.equal(400);
+                expect(err.body).to.equal('');
             });
         });
 
-        it('GET with JSON response containing message attribute', function (done) {
+        it('GET with JSON response containing message attribute', function () {
             mockBody = '{"message":"some body content"}';
             fetchMock.get('/url', {
                 body: mockBody,
                 status: responseStatus,
             });
 
-            http.get('/url', { 'X-Foo': 'foo' }, {}, function (err) {
+            return http.get('/url', { 'X-Foo': 'foo' }, {}).catch((err) => {
                 expect(err.message).to.equal('some body content');
                 expect(err.statusCode).to.equal(400);
                 expect(err.body).to.deep.equal({
                     message: 'some body content',
                 });
-                done();
             });
         });
 
-        it('GET with JSON response not containing message attribute', function (done) {
+        it('GET with JSON response not containing message attribute', function () {
             mockBody = '{"other":"some body content"}';
             fetchMock.get('/url', {
                 body: mockBody,
                 status: responseStatus,
             });
 
-            http.get('/url', { 'X-Foo': 'foo' }, {}, function (err) {
+            return http.get('/url', { 'X-Foo': 'foo' }, {}).catch((err) => {
                 expect(err.message).to.equal(mockBody);
                 expect(err.statusCode).to.equal(400);
                 expect(err.body).to.deep.equal({
                     other: 'some body content',
                 });
-                done();
             });
         });
 
@@ -218,18 +201,17 @@ describe('Client HTTP', function () {
         // may remove body content
         // and replace it with 'Bad Request'
         // if not configured to allow content throughput
-        it('GET with plain text', function (done) {
+        it('GET with plain text', function () {
             mockBody = 'Bad Request';
             fetchMock.get('/url', {
                 body: mockBody,
                 status: responseStatus,
             });
 
-            http.get('/url', { 'X-Foo': 'foo' }, {}, function (err) {
+            return http.get('/url', { 'X-Foo': 'foo' }, {}).catch((err) => {
                 expect(err.message).to.equal(mockBody);
                 expect(err.statusCode).to.equal(400);
                 expect(err.body).to.equal(mockBody);
-                done();
             });
         });
     });
@@ -250,13 +232,13 @@ describe('Client HTTP', function () {
             expect(req1.request.body).to.equal(req2.request.body);
         };
 
-        it('GET with no retry', function (done) {
+        it('GET with no retry', function () {
             fetchMock.get('/url', {
                 body: mockBody,
                 status: responseStatus,
             });
 
-            http.get('/url', { 'X-Foo': 'foo' }, {}, function (err) {
+            return http.get('/url', { 'X-Foo': 'foo' }, {}).catch((err) => {
                 const options = fetchMock.lastCall().request;
                 expect(fetchMock.calls()).to.have.lengthOf(1);
                 expect(options.url).to.equal('/url');
@@ -268,26 +250,27 @@ describe('Client HTTP', function () {
                 expect(err.message).to.equal('BODY');
                 expect(err.statusCode).to.equal(408);
                 expect(err.body).to.equal('BODY');
-                done();
             });
         });
 
-        it('GET with retry', function (done) {
+        it('GET with retry', function () {
             fetchMock.get('/url', {
                 body: mockBody,
                 status: responseStatus,
             });
 
-            http.get(
-                '/url',
-                { 'X-Foo': 'foo' },
-                {
-                    retry: {
-                        interval: 200,
-                        maxRetries: 1,
-                    },
-                },
-                function (err) {
+            return http
+                .get(
+                    '/url',
+                    { 'X-Foo': 'foo' },
+                    {
+                        retry: {
+                            interval: 200,
+                            maxRetries: 1,
+                        },
+                    }
+                )
+                .catch((err) => {
                     expect(fetchMock.calls()).to.have.lengthOf(2);
                     const options = fetchMock.lastCall().request;
                     expect(options.url).to.equal('/url');
@@ -302,38 +285,34 @@ describe('Client HTTP', function () {
 
                     const [req1, req2] = fetchMock.calls();
                     expectRequestsToBeEqual(req1, req2);
-
-                    done();
-                }
-            );
+                });
         });
 
-        it('GET with retry and custom status code', function (done) {
+        it('GET with retry and custom status code', function () {
             responseStatus = 502;
             fetchMock.get('/url', {
                 body: mockBody,
                 status: responseStatus,
             });
 
-            http.get(
-                '/url',
-                { 'X-Foo': 'foo' },
-                {
-                    retry: {
-                        interval: 20,
-                        maxRetries: 1,
-                        statusCodes: [502],
-                    },
-                },
-                function () {
+            return http
+                .get(
+                    '/url',
+                    { 'X-Foo': 'foo' },
+                    {
+                        retry: {
+                            interval: 20,
+                            maxRetries: 1,
+                            statusCodes: [502],
+                        },
+                    }
+                )
+                .catch(() => {
                     expect(fetchMock.calls()).to.have.lengthOf(2);
 
                     const [req1, req2] = fetchMock.calls();
                     expectRequestsToBeEqual(req1, req2);
-
-                    done();
-                }
-            );
+                });
         });
     });
 
@@ -356,38 +335,32 @@ describe('Client HTTP', function () {
                 config = { xhrTimeout: 3000 };
             });
 
-            it('should use xhrTimeout for GET', function (done) {
+            it('should use xhrTimeout for GET', function () {
                 fetchMock.get('/url', {
                     body: mockBody,
                     status: responseStatus,
                 });
 
-                http.get('/url', { 'X-Foo': 'foo' }, config, function () {
+                return http.get('/url', { 'X-Foo': 'foo' }, config).then(() => {
                     sinon.assert.calledWith(setTimeout, sinon.match.func, 3000);
-                    done();
                 });
             });
 
-            it('should use xhrTimeout for POST', function (done) {
+            it('should use xhrTimeout for POST', function () {
                 fetchMock.post('/url', {
                     body: mockBody,
                     status: responseStatus,
                 });
 
-                http.post(
-                    '/url',
-                    { 'X-Foo': 'foo' },
-                    { data: 'data' },
-                    config,
-                    function () {
+                return http
+                    .post('/url', { 'X-Foo': 'foo' }, { data: 'data' }, config)
+                    .then(() => {
                         sinon.assert.calledWith(
                             setTimeout,
                             sinon.match.func,
                             3000
                         );
-                        done();
-                    }
-                );
+                    });
             });
         });
 
@@ -396,57 +369,48 @@ describe('Client HTTP', function () {
                 config = { xhrTimeout: 3000, timeout: 6000 };
             });
 
-            it('should override default xhrTimeout for GET', function (done) {
+            it('should override default xhrTimeout for GET', function () {
                 fetchMock.get('/url', {
                     body: mockBody,
                     status: responseStatus,
                 });
 
-                http.get('/url', { 'X-Foo': 'foo' }, config, function () {
+                return http.get('/url', { 'X-Foo': 'foo' }, config).then(() => {
                     sinon.assert.calledWith(setTimeout, sinon.match.func, 6000);
-                    done();
                 });
             });
 
-            it('should override default xhrTimeout for POST', function (done) {
+            it('should override default xhrTimeout for POST', function () {
                 fetchMock.post('/url', {
                     body: mockBody,
                     status: responseStatus,
                 });
 
-                http.post(
-                    '/url',
-                    { 'X-Foo': 'foo' },
-                    { data: 'data' },
-                    config,
-                    function () {
+                return http
+                    .post('/url', { 'X-Foo': 'foo' }, { data: 'data' }, config)
+                    .then(() => {
                         sinon.assert.calledWith(
                             setTimeout,
                             sinon.match.func,
                             6000
                         );
-                        done();
-                    }
-                );
+                    });
             });
         });
     });
 
     describe('request errors', function () {
-        it('should pass-through any xhr error', function (done) {
+        it('should pass-through any xhr error', function () {
             responseStatus = 0;
             fetchMock.get('/url', {
                 throws: new Error('AnyError'),
                 status: responseStatus,
             });
 
-            http.get('/url', {}, { xhrTimeout: 42 }, function (err, response) {
-                expect(response).to.equal(undefined);
+            return http.get('/url', {}, { xhrTimeout: 42 }).catch((err) => {
                 expect(err.message).to.equal('AnyError');
                 expect(err.timeout).to.equal(42);
                 expect(err.url).to.equal('/url');
-
-                done();
             });
         });
     });


### PR DESCRIPTION
Summary of changes:
- replace `get` and `post` with only one method:`httpRequest`
- `httpRequest` always returns a promise (fetcher is now the only responsible for handling the callback flow)
- Simplify http request options normalization

Again, I recommend you to review commit by commit ;)

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
