### PR TITLE
refactor: join options logic from http and fetchr client modules

### DIFF
--- a/libs/fetcher.client.js
+++ b/libs/fetcher.client.js
@@ -14,7 +14,6 @@ var normalizeOptions = require('./util/normalizeOptions');
 
 var DEFAULT_PATH = '/api';
 var DEFAULT_TIMEOUT = 3000;
-var OP_READ = 'read';
 
 /**
  * A RequestClient instance represents a single fetcher request.
@@ -33,7 +32,7 @@ function Request(operation, resource, options) {
         throw new Error('Resource is required for a fetcher request');
     }
 
-    this.operation = operation || OP_READ;
+    this.operation = operation;
     this.resource = resource;
     this.options = options;
 

--- a/libs/fetcher.client.js
+++ b/libs/fetcher.client.js
@@ -10,7 +10,7 @@
  * @module Fetcher
  */
 var httpRequest = require('./util/http.client').default;
-var defaultConstructGetUri = require('./util/defaultConstructGetUri');
+var urlUtil = require('./util/url');
 var forEach = require('./util/forEach');
 var pickContext = require('./util/pickContext');
 
@@ -197,7 +197,7 @@ function executeRequest(request) {
         var buildGetUrl =
             typeof config.constructGetUri === 'function'
                 ? config.constructGetUri
-                : defaultConstructGetUri;
+                : urlUtil.buildGETUrl;
 
         var context = pickContext(
             request.options.context,
@@ -213,11 +213,11 @@ function executeRequest(request) {
             context,
         ];
 
-        // If a custom getUriFn returns falsy value, we should run defaultConstructGetUri
+        // If a custom getUriFn returns falsy value, we should run urlUtil.buildGETUrl
         // TODO: Add test for this fallback
         options.url =
             buildGetUrl.apply(request, args) ||
-            defaultConstructGetUri.apply(request, args);
+            urlUtil.buildGETUrl.apply(request, args);
 
         if (options.url.length <= MAX_URI_LEN) {
             return httpRequest(options);

--- a/libs/fetcher.client.js
+++ b/libs/fetcher.client.js
@@ -3,8 +3,6 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
-/*jslint plusplus:true,nomen:true */
-
 /**
  * Fetcher is a CRUD interface for your data.
  * @module Fetcher

--- a/libs/fetcher.client.js
+++ b/libs/fetcher.client.js
@@ -7,7 +7,7 @@
  * Fetcher is a CRUD interface for your data.
  * @module Fetcher
  */
-var httpRequest = require('./util/http.client').default;
+var httpRequest = require('./util/httpRequest');
 var normalizeOptions = require('./util/normalizeOptions');
 
 var DEFAULT_PATH = '/api';

--- a/libs/fetcher.client.js
+++ b/libs/fetcher.client.js
@@ -35,16 +35,8 @@ function Request(operation, resource, options) {
 
     this.operation = operation || OP_READ;
     this.resource = resource;
-    this.options = {
-        headers: options.headers,
-        xhrPath: options.xhrPath || DEFAULT_PATH,
-        xhrTimeout: options.xhrTimeout || DEFAULT_TIMEOUT,
-        corsPath: options.corsPath,
-        context: options.context || {},
-        contextPicker: options.contextPicker || {},
-        statsCollector: options.statsCollector,
-        _serviceMeta: options._serviceMeta || [],
-    };
+    this.options = options;
+
     this._params = {};
     this._body = null;
     this._clientConfig = {};
@@ -186,11 +178,11 @@ function Fetcher(options) {
     this._serviceMeta = [];
     this.options = {
         headers: options.headers,
-        xhrPath: options.xhrPath,
-        xhrTimeout: options.xhrTimeout,
+        xhrPath: options.xhrPath || DEFAULT_PATH,
+        xhrTimeout: options.xhrTimeout || DEFAULT_TIMEOUT,
         corsPath: options.corsPath,
-        context: options.context,
-        contextPicker: options.contextPicker,
+        context: options.context || {},
+        contextPicker: options.contextPicker || {},
         statsCollector: options.statsCollector,
         _serviceMeta: this._serviceMeta,
     };

--- a/libs/fetcher.client.js
+++ b/libs/fetcher.client.js
@@ -11,7 +11,6 @@
  */
 var httpRequest = require('./util/http.client').default;
 var urlUtil = require('./util/url');
-var forEach = require('./util/forEach');
 var pickContext = require('./util/pickContext');
 
 var DEFAULT_PATH = '/api';
@@ -225,7 +224,7 @@ function executeRequest(request) {
     }
 
     options.method = 'POST';
-    options.url = request._constructPostUri(baseUrl);
+    options.url = urlUtil.buildPOSTUrl(baseUrl, request);
     options.data = {
         body: request._body,
         context: request.options.context,
@@ -236,36 +235,6 @@ function executeRequest(request) {
 
     return httpRequest(options);
 }
-
-/**
- * Build a final uri by adding query params to base uri from this.context
- * @method _constructPostUri
- * @param {String} uri the base uri
- * @private
- */
-Request.prototype._constructPostUri = function (uri) {
-    var query = [];
-    var final_uri = uri;
-
-    // We only want to append the resource if the uri is the fetchr
-    // one. If users set a custom uri (through clientConfig method or
-    // by passing a config obejct to the request), we should not
-    // modify it.
-    if (!this._clientConfig.uri) {
-        final_uri += '/' + this.resource;
-    }
-
-    forEach(
-        pickContext(this.options.context, this.options.contextPicker, 'POST'),
-        function eachContext(v, k) {
-            query.push(k + '=' + encodeURIComponent(v));
-        }
-    );
-    if (query.length > 0) {
-        final_uri += '?' + query.sort().join('&');
-    }
-    return final_uri;
-};
 
 /**
  * Fetcher class for the client. Provides CRUD methods.

--- a/libs/util/defaultConstructGetUri.js
+++ b/libs/util/defaultConstructGetUri.js
@@ -2,76 +2,12 @@
  * Copyright 2015, Yahoo! Inc.
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
+
+// TODO: remove this module as soon as fluxible-plugin-fetchr starts
+// using the new url module.
+
 'use strict';
 
-var forEach = require('./forEach');
+var url = require('./url');
 
-function isObject(value) {
-    var type = typeof value;
-    return value != null && (type == 'object' || type == 'function');
-}
-
-function jsonifyComplexType(value) {
-    if (Array.isArray(value) || isObject(value)) {
-        return JSON.stringify(value);
-    }
-    return value;
-}
-
-/**
- * Construct GET URI.
- * @method defaultConstructGetUri
- * @param {String} uri base URI
- * @param {String} resource Resource name
- * @param {Object} params Parameters to be serialized
- * @param {Object} config Configuration object
- * @param {String} config.id_param  Name of the id parameter
- * @param {Object} context Context object, which will become query params
- */
-module.exports = function defaultConstructGetUri(
-    baseUri,
-    resource,
-    params,
-    config,
-    context
-) {
-    var query = [];
-    var matrix = [];
-    var id_param = config.id_param;
-    var id_val;
-    var final_uri = baseUri + '/' + resource;
-
-    if (params) {
-        forEach(params, function eachParam(v, k) {
-            if (k === id_param) {
-                id_val = encodeURIComponent(v);
-            } else if (v !== undefined) {
-                try {
-                    matrix.push(
-                        k + '=' + encodeURIComponent(jsonifyComplexType(v))
-                    );
-                } catch (err) {
-                    console.debug('jsonifyComplexType failed: ' + err);
-                }
-            }
-        });
-    }
-
-    if (context) {
-        forEach(context, function eachContext(v, k) {
-            query.push(k + '=' + encodeURIComponent(jsonifyComplexType(v)));
-        });
-    }
-
-    if (id_val) {
-        final_uri += '/' + id_param + '/' + id_val;
-    }
-    if (matrix.length > 0) {
-        final_uri += ';' + matrix.sort().join(';');
-    }
-    if (query.length > 0) {
-        final_uri += '?' + query.sort().join('&');
-    }
-
-    return final_uri;
-};
+module.exports = url.buildGETUrl;

--- a/libs/util/http.client.js
+++ b/libs/util/http.client.js
@@ -7,17 +7,6 @@
  * @module rest-http
  */
 
-function parseResponse(response) {
-    if (response) {
-        try {
-            return JSON.parse(response);
-        } catch (e) {
-            return null;
-        }
-    }
-    return null;
-}
-
 function shouldRetry(options, statusCode, attempt) {
     if (attempt >= options.retry.maxRetries) {
         return false;
@@ -99,8 +88,8 @@ function io(options, controller) {
             clearTimeout(timeoutId);
 
             if (response.ok) {
-                return response.text().then(function (responseBody) {
-                    return parseResponse(responseBody);
+                return response.json().catch(function () {
+                    return null;
                 });
             } else {
                 return response.text().then(function (responseBody) {

--- a/libs/util/http.client.js
+++ b/libs/util/http.client.js
@@ -81,17 +81,17 @@ function FetchrError(options, request, response, responseBody, originalError) {
     return err;
 }
 
-function io(options) {
+function io(options, controller) {
     var request = new Request(options.url, {
         body: options.body,
         credentials: options.credentials,
         headers: options.headers,
         method: options.method,
-        signal: options.controller.signal,
+        signal: controller.signal,
     });
 
     var timeoutId = setTimeout(function () {
-        options.controller.abort();
+        controller.abort();
     }, options.timeout);
 
     return fetch(request).then(
@@ -124,15 +124,7 @@ function httpRequest(options, attempt) {
     var controller = new AbortController();
     var currentAttempt = attempt || 0;
 
-    var promise = io({
-        body: options.body,
-        controller: controller,
-        credentials: options.credentials,
-        headers: options.headers,
-        method: options.method,
-        timeout: options.timeout,
-        url: options.url,
-    }).catch(function (err) {
+    var promise = io(options, controller).catch(function (err) {
         if (!shouldRetry(options, err.statusCode, currentAttempt)) {
             throw err;
         }

--- a/libs/util/http.client.js
+++ b/libs/util/http.client.js
@@ -7,26 +7,6 @@
  * @module rest-http
  */
 
-function shouldRetry(options, statusCode, attempt) {
-    if (attempt >= options.retry.maxRetries) {
-        return false;
-    }
-
-    if (options.method === 'POST' && !options.retry.retryOnPost) {
-        return false;
-    }
-
-    return options.retry.statusCodes.indexOf(statusCode) !== -1;
-}
-
-function delayPromise(fn, delay) {
-    return new Promise(function (resolve, reject) {
-        setTimeout(function () {
-            fn().then(resolve, reject);
-        }, delay);
-    });
-}
-
 function FetchrError(options, request, response, responseBody, originalError) {
     var err = originalError;
     var status = response ? response.status : 0;
@@ -68,6 +48,26 @@ function FetchrError(options, request, response, responseBody, originalError) {
     err.url = request.url;
 
     return err;
+}
+
+function shouldRetry(options, statusCode, attempt) {
+    if (attempt >= options.retry.maxRetries) {
+        return false;
+    }
+
+    if (options.method === 'POST' && !options.retry.retryOnPost) {
+        return false;
+    }
+
+    return options.retry.statusCodes.indexOf(statusCode) !== -1;
+}
+
+function delayPromise(fn, delay) {
+    return new Promise(function (resolve, reject) {
+        setTimeout(function () {
+            fn().then(resolve, reject);
+        }, delay);
+    });
 }
 
 function io(options, controller) {

--- a/libs/util/httpRequest.js
+++ b/libs/util/httpRequest.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * @module rest-http
+ * @module httpRequest
  */
 
 function FetchrError(options, request, response, responseBody, originalError) {
@@ -138,4 +138,4 @@ function httpRequest(options, attempt) {
     };
 }
 
-module.exports.default = httpRequest;
+module.exports = httpRequest;

--- a/libs/util/normalizeOptions.js
+++ b/libs/util/normalizeOptions.js
@@ -1,0 +1,72 @@
+var pickContext = require('./pickContext');
+var url = require('./url');
+
+var MAX_URI_LEN = 2048;
+
+function normalizeOptions(request) {
+    var options = {};
+
+    var config = Object.assign(
+        {
+            unsafeAllowRetry: request.operation === 'read',
+            xhrTimeout: request.options.xhrTimeout,
+        },
+        request._clientConfig
+    );
+    options.config = config;
+    options.headers = config.headers || request.options.headers || {};
+
+    var baseUrl = config.uri;
+    if (!baseUrl) {
+        baseUrl = config.cors
+            ? request.options.corsPath
+            : request.options.xhrPath;
+    }
+
+    if (request.operation === 'read' && !config.post_for_read) {
+        options.method = 'GET';
+
+        var buildGetUrl =
+            typeof config.constructGetUri === 'function'
+                ? config.constructGetUri
+                : url.buildGETUrl;
+
+        var context = pickContext(
+            request.options.context,
+            request.options.contextPicker,
+            'GET'
+        );
+
+        var args = [
+            baseUrl,
+            request.resource,
+            request._params,
+            request._clientConfig,
+            context,
+        ];
+
+        // If a custom getUriFn returns falsy value, we should run urlUtil.buildGETUrl
+        // TODO: Add test for this fallback
+        options.url =
+            buildGetUrl.apply(request, args) ||
+            url.buildGETUrl.apply(request, args);
+
+        if (options.url.length <= MAX_URI_LEN) {
+            return options;
+        }
+    }
+
+    options.method = 'POST';
+    options.url = url.buildPOSTUrl(baseUrl, request);
+    options.data = {
+        body: request._body,
+        context: request.options.context,
+        operation: request.operation,
+        params: request._params,
+        resource: request.resource,
+    };
+
+    return options;
+}
+
+module.exports = normalizeOptions;

--- a/libs/util/url.js
+++ b/libs/util/url.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+'use strict';
+
+var forEach = require('./forEach');
+
+function isObject(value) {
+    var type = typeof value;
+    return value != null && (type == 'object' || type == 'function');
+}
+
+function jsonifyComplexType(value) {
+    if (Array.isArray(value) || isObject(value)) {
+        return JSON.stringify(value);
+    }
+    return value;
+}
+
+/**
+ * Construct GET URL.
+ * @param {String} baseUrl
+ * @param {String} resource Resource name
+ * @param {Object} params Parameters to be serialized
+ * @param {Object} config Configuration object
+ * @param {String} config.id_param  Name of the id parameter
+ * @param {Object} context Context object, which will become query params
+ */
+function buildGETUrl(baseUrl, resource, params, config, context) {
+    var query = [];
+    var matrix = [];
+    var idParam = config.id_param;
+    var idVal;
+    var finalUrl = baseUrl + '/' + resource;
+
+    if (params) {
+        forEach(params, function eachParam(v, k) {
+            if (k === idParam) {
+                idVal = encodeURIComponent(v);
+            } else if (v !== undefined) {
+                try {
+                    matrix.push(
+                        k + '=' + encodeURIComponent(jsonifyComplexType(v))
+                    );
+                } catch (err) {
+                    console.debug('jsonifyComplexType failed: ' + err);
+                }
+            }
+        });
+    }
+
+    if (context) {
+        forEach(context, function eachContext(v, k) {
+            query.push(k + '=' + encodeURIComponent(jsonifyComplexType(v)));
+        });
+    }
+
+    if (idVal) {
+        finalUrl += '/' + idParam + '/' + idVal;
+    }
+    if (matrix.length > 0) {
+        finalUrl += ';' + matrix.sort().join(';');
+    }
+    if (query.length > 0) {
+        finalUrl += '?' + query.sort().join('&');
+    }
+
+    return finalUrl;
+}
+
+module.exports = {
+    buildGETUrl: buildGETUrl,
+};

--- a/libs/util/url.js
+++ b/libs/util/url.js
@@ -5,6 +5,7 @@
 'use strict';
 
 var forEach = require('./forEach');
+var pickContext = require('./pickContext');
 
 function isObject(value) {
     var type = typeof value;
@@ -69,6 +70,41 @@ function buildGETUrl(baseUrl, resource, params, config, context) {
     return finalUrl;
 }
 
+/**
+ * Build a final url by adding query params to the base url from
+ * request.context
+ * @param {String} baseUrl
+ * @param {Request} request
+ */
+function buildPOSTUrl(baseUrl, request) {
+    var query = [];
+    var finalUrl = baseUrl;
+
+    // We only want to append the resource if the uri is the fetchr
+    // one. If users set a custom uri (through clientConfig method or
+    // by passing a config obejct to the request), we should not
+    // modify it.
+    if (!request._clientConfig.uri) {
+        finalUrl += '/' + request.resource;
+    }
+
+    forEach(
+        pickContext(
+            request.options.context,
+            request.options.contextPicker,
+            'POST'
+        ),
+        function eachContext(v, k) {
+            query.push(k + '=' + encodeURIComponent(v));
+        }
+    );
+    if (query.length > 0) {
+        finalUrl += '?' + query.sort().join('&');
+    }
+    return finalUrl;
+}
+
 module.exports = {
     buildGETUrl: buildGETUrl,
+    buildPOSTUrl: buildPOSTUrl,
 };

--- a/tests/unit/libs/fetcher.client.js
+++ b/tests/unit/libs/fetcher.client.js
@@ -12,7 +12,7 @@ var sinon = require('sinon');
 var supertest = require('supertest');
 
 var Fetcher = require('../../../libs/fetcher.client');
-var defaultConstructGetUri = require('../../../libs/util/defaultConstructGetUri');
+var urlUtil = require('../../../libs/util/url');
 var httpRequest = require('../../../libs/util/http.client').default;
 var testCrud = require('../../util/testCrud');
 var defaultOptions = require('../../util/defaultOptions');
@@ -365,9 +365,7 @@ describe('Client Fetcher', function () {
     describe('Custom constructGetUri', () => {
         it('is called correctly', () => {
             const fetcher = new Fetcher({});
-            const constructGetUri = sinon
-                .stub()
-                .callsFake(defaultConstructGetUri);
+            const constructGetUri = sinon.stub().callsFake(urlUtil.buildGETUrl);
 
             return fetcher
                 .read('mock_service', { foo: 'bar' }, { constructGetUri })

--- a/tests/unit/libs/fetcher.client.js
+++ b/tests/unit/libs/fetcher.client.js
@@ -210,7 +210,7 @@ describe('Client Fetcher', function () {
             before(function () {
                 mockery.registerMock('./util/http.client', {
                     default: function (options) {
-                        expect(options.config.xhrTimeout).to.equal(4000);
+                        expect(options.timeout).to.equal(4000);
                         return httpRequest(options);
                     },
                 });
@@ -235,8 +235,7 @@ describe('Client Fetcher', function () {
             before(function () {
                 mockery.registerMock('./util/http.client', {
                     default: function (options) {
-                        expect(options.config.xhrTimeout).to.equal(4000);
-                        expect(options.config.timeout).to.equal(5000);
+                        expect(options.timeout).to.equal(5000);
                         return httpRequest(options);
                     },
                 });
@@ -271,7 +270,7 @@ describe('Client Fetcher', function () {
             before(function () {
                 mockery.registerMock('./util/http.client', {
                     default: function (options) {
-                        expect(options.config.xhrTimeout).to.equal(3000);
+                        expect(options.timeout).to.equal(3000);
                         return httpRequest(options);
                     },
                 });

--- a/tests/unit/libs/fetcher.client.js
+++ b/tests/unit/libs/fetcher.client.js
@@ -13,7 +13,7 @@ var supertest = require('supertest');
 
 var Fetcher = require('../../../libs/fetcher.client');
 var urlUtil = require('../../../libs/util/url');
-var httpRequest = require('../../../libs/util/http.client').default;
+var httpRequest = require('../../../libs/util/httpRequest');
 var testCrud = require('../../util/testCrud');
 var defaultOptions = require('../../util/defaultOptions');
 
@@ -208,11 +208,9 @@ describe('Client Fetcher', function () {
     describe('Timeout', function () {
         describe('should be configurable globally', function () {
             before(function () {
-                mockery.registerMock('./util/http.client', {
-                    default: function (options) {
-                        expect(options.timeout).to.equal(4000);
-                        return httpRequest(options);
-                    },
+                mockery.registerMock('./util/httpRequest', function (options) {
+                    expect(options.timeout).to.equal(4000);
+                    return httpRequest(options);
                 });
                 mockery.enable({
                     useCleanCache: true,
@@ -226,18 +224,16 @@ describe('Client Fetcher', function () {
             });
             testCrud(params, body, config, callback, resolve, reject);
             after(function () {
-                mockery.deregisterMock('./util/http.client');
+                mockery.deregisterMock('./util/httpRequest');
                 mockery.disable();
             });
         });
 
         describe('should be configurable per each fetchr call', function () {
             before(function () {
-                mockery.registerMock('./util/http.client', {
-                    default: function (options) {
-                        expect(options.timeout).to.equal(5000);
-                        return httpRequest(options);
-                    },
+                mockery.registerMock('./util/httpRequest', function (options) {
+                    expect(options.timeout).to.equal(5000);
+                    return httpRequest(options);
                 });
                 mockery.enable({
                     useCleanCache: true,
@@ -261,18 +257,16 @@ describe('Client Fetcher', function () {
                 reject: reject,
             });
             after(function () {
-                mockery.deregisterMock('./util/http.client');
+                mockery.deregisterMock('./util/httpRequest');
                 mockery.disable();
             });
         });
 
         describe('should default to DEFAULT_TIMEOUT of 3000', function () {
             before(function () {
-                mockery.registerMock('./util/http.client', {
-                    default: function (options) {
-                        expect(options.timeout).to.equal(3000);
-                        return httpRequest(options);
-                    },
+                mockery.registerMock('./util/httpRequest', function (options) {
+                    expect(options.timeout).to.equal(3000);
+                    return httpRequest(options);
                 });
                 mockery.enable({
                     useCleanCache: true,
@@ -285,7 +279,7 @@ describe('Client Fetcher', function () {
             });
             testCrud(params, body, config, callback, resolve, reject);
             after(function () {
-                mockery.deregisterMock('./util/http.client');
+                mockery.deregisterMock('./util/httpRequest');
                 mockery.disable();
             });
         });
@@ -386,13 +380,9 @@ describe('Client Fetcher', function () {
 
         describe('should be configurable globally', function () {
             before(function () {
-                mockery.registerMock('./util/http.client', {
-                    default: function (options) {
-                        expect(options.headers['X-APP-VERSION']).to.equal(
-                            VERSION
-                        );
-                        return httpRequest(options);
-                    },
+                mockery.registerMock('./util/httpRequest', function (options) {
+                    expect(options.headers['X-APP-VERSION']).to.equal(VERSION);
+                    return httpRequest(options);
                 });
                 mockery.enable({
                     useCleanCache: true,
@@ -408,20 +398,16 @@ describe('Client Fetcher', function () {
             });
             testCrud(params, body, config, callback, resolve, reject);
             after(function () {
-                mockery.deregisterMock('./util/http.client');
+                mockery.deregisterMock('./util/httpRequest');
                 mockery.disable();
             });
         });
 
         describe('should be configurable per request', function () {
             before(function () {
-                mockery.registerMock('./util/http.client', {
-                    default: function (options) {
-                        expect(options.headers['X-APP-VERSION']).to.equal(
-                            VERSION
-                        );
-                        return httpRequest(options);
-                    },
+                mockery.registerMock('./util/httpRequest', function (options) {
+                    expect(options.headers['X-APP-VERSION']).to.equal(VERSION);
+                    return httpRequest(options);
                 });
                 mockery.enable({
                     useCleanCache: true,
@@ -447,7 +433,7 @@ describe('Client Fetcher', function () {
                 reject: reject,
             });
             after(function () {
-                mockery.deregisterMock('./util/http.client');
+                mockery.deregisterMock('./util/httpRequest');
                 mockery.disable();
             });
         });

--- a/tests/unit/libs/util/httpRequest.js
+++ b/tests/unit/libs/util/httpRequest.js
@@ -8,7 +8,7 @@
 const fetchMock = require('fetch-mock');
 const { expect } = require('chai');
 const sinon = require('sinon');
-const httpRequest = require('../../../../libs/util/http.client').default;
+const httpRequest = require('../../../../libs/util/httpRequest');
 
 const contentTypeHeader = { ['Content-Type']: 'application/json' };
 const customHeader = { 'X-Foo': 'foo' };


### PR DESCRIPTION
This is the last big refactoring one. Here, I'm merging the code related to options normalization from the `http.client` and `fetchr.cleint` modules. As you can see, when you put both together, we have a bunch of code (that I'll probably simplify in another PR).

By centralizing the options we basically create only one interface that is passed down to all functions (it will be helpful when migrating to ts). 

But more importantly, `httpRequest` does not compute the options unnecessarily on every retry. This makes the plate clean to fix the corner cases that I mentioned in the other PR:
- do not retry user requests aborted by the user
- add abort support for the promise flow

There will be also another PR improving the `FetchrError` class:
- Make it inherit from `Error`;
- Attach the `options` object;
- Add `name`, `message` and `reason` fields to make it easier for users to report/log errors;

Since all this changes should be backward compatible, I would like to do it before migrating to ts/change the API.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
