### PR TITLE
refactor: simplify FetchrError and fix Error inheritance

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ export default {
         const err = new Error('it failed');
         err.statusCode = 404;
         err.output = { message: 'Not found', more: 'meta data' };
+        err.meta = { foo: 'bar' };
         return callback(err);
     },
 };
@@ -235,10 +236,18 @@ And in your service call:
 ```js
 fetcher
     .read('someData')
-    .params({id: ###})
+    .params({ id: '42' })
     .end(function (err, data, meta) {
         if (err) {
-            // err.output will be { message: "Not found", more: "meta data" }
+            // err instanceof FetchrError -> true
+            // err.message -> "Not found"
+            // err.meta -> { foo: 'bar' }
+            // err.name = 'FetchrError'
+            // err.output -> { message: "Not found", more: "meta data" }
+            // err.rawRequest -> { headers: {}, method: 'GET', url: '/api/someData' }
+            // err.statusCode -> 404
+            // err.timeout -> 3000
+            // err.url -> '/api/someData'
         }
     });
 ```

--- a/libs/fetcher.js
+++ b/libs/fetcher.js
@@ -11,6 +11,13 @@ const OP_UPDATE = 'update';
 const OP_DELETE = 'delete';
 const RESOURCE_SANTIZER_REGEXP = /[^\w.]+/g;
 
+class FetchrError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'FetchrError';
+    }
+}
+
 function parseValue(value) {
     // take care of value of type: array, object
     try {
@@ -132,7 +139,7 @@ class Request {
      */
     constructor(operation, resource, options = {}) {
         if (!resource) {
-            throw new Error('Resource is required for a fetcher request');
+            throw new FetchrError('Resource is required for a fetcher request');
         }
 
         this.operation = operation || OP_READ;
@@ -278,7 +285,7 @@ function executeRequest(request, resolve, reject) {
     try {
         const service = Fetcher.getService(request.resource);
         if (!service[op]) {
-            throw new Error(
+            throw new FetchrError(
                 `operation: ${op} is undefined on service: ${request.resource}`
             );
         }
@@ -339,7 +346,7 @@ class Fetcher {
      */
     static registerService(service) {
         if (!service) {
-            throw new Error(
+            throw new FetchrError(
                 'Fetcher.registerService requires a service definition (ex. registerService(service)).'
             );
         }
@@ -351,7 +358,7 @@ class Fetcher {
             resource = service.name;
             Fetcher._deprecatedServicesDefinitions.push(resource);
         } else {
-            throw new Error(
+            throw new FetchrError(
                 '"resource" property is missing in service definition.'
             );
         }
@@ -383,7 +390,7 @@ class Fetcher {
         //Access service by name
         const service = Fetcher.isRegistered(name);
         if (!service) {
-            throw new Error(
+            throw new FetchrError(
                 `Service "${sanitizeResourceName(name)}" could not be found`
             );
         }

--- a/libs/util/httpRequest.js
+++ b/libs/util/httpRequest.js
@@ -13,21 +13,15 @@ function FetchrError(options, request, response, responseBody, originalError) {
     var errMessage, errBody;
 
     if (!err && (status === 0 || (status >= 400 && status < 600))) {
-        if (typeof responseBody === 'string') {
-            try {
-                errBody = JSON.parse(responseBody);
-                if (errBody.message) {
-                    errMessage = errBody.message;
-                } else {
-                    errMessage = responseBody;
-                }
-            } catch (e) {
+        try {
+            errBody = JSON.parse(responseBody);
+            if (errBody.message) {
+                errMessage = errBody.message;
+            } else {
                 errMessage = responseBody;
             }
-        } else {
-            errMessage = status
-                ? 'Error ' + status
-                : 'Internal Fetchr XMLHttpRequest Error';
+        } catch (e) {
+            errMessage = responseBody;
         }
 
         err = new Error(errMessage);

--- a/libs/util/httpRequest.js
+++ b/libs/util/httpRequest.js
@@ -8,41 +8,36 @@
  */
 
 function FetchrError(options, request, response, responseBody, originalError) {
-    var err = originalError;
-    var status = response ? response.status : 0;
-    var errMessage, errBody;
-
-    if (!err) {
-        try {
-            errBody = JSON.parse(responseBody);
-            if (errBody.message) {
-                errMessage = errBody.message;
-            } else {
-                errMessage = responseBody;
-            }
-        } catch (e) {
-            errMessage = responseBody;
-        }
-
-        err = new Error(errMessage);
-        err.body = errBody || responseBody;
-        if (err.body) {
-            err.output = err.body.output;
-            err.meta = err.body.meta;
-        }
-    }
-
-    err.rawRequest = {
+    this.name = 'FetchrError';
+    this.rawRequest = {
         headers: options.headers,
         method: request.method,
         url: request.url,
     };
-    err.statusCode = status;
-    err.timeout = options.timeout;
-    err.url = request.url;
+    this.statusCode = response ? response.status : 0;
+    this.timeout = options.timeout;
+    this.url = request.url;
 
-    return err;
+    if (originalError) {
+        this.message = originalError.message;
+    } else {
+        try {
+            this.body = JSON.parse(responseBody);
+            this.message = this.body.message || responseBody;
+        } catch (e) {
+            this.body = responseBody;
+            this.message = responseBody;
+        }
+
+        if (this.body) {
+            this.output = this.body.output;
+            this.meta = this.body.meta;
+        }
+    }
 }
+
+FetchrError.prototype = Object.create(Error.prototype);
+FetchrError.prototype.constructor = FetchrError;
 
 function shouldRetry(options, statusCode, attempt) {
     if (attempt >= options.retry.maxRetries) {

--- a/libs/util/httpRequest.js
+++ b/libs/util/httpRequest.js
@@ -12,7 +12,7 @@ function FetchrError(options, request, response, responseBody, originalError) {
     var status = response ? response.status : 0;
     var errMessage, errBody;
 
-    if (!err && (status === 0 || (status >= 400 && status < 600))) {
+    if (!err) {
         try {
             errBody = JSON.parse(responseBody);
             if (errBody.message) {

--- a/tests/functional/fetchr.test.js
+++ b/tests/functional/fetchr.test.js
@@ -139,8 +139,11 @@ describe('client/server integration', () => {
                 });
 
                 expect(response).to.deep.equal({
+                    body: null,
                     message: 'Failed to fetch',
+                    meta: null,
                     name: 'FetchrError',
+                    output: null,
                     statusCode: 0,
                     rawRequest: {
                         url: 'http://localhost:3001/error',
@@ -217,7 +220,9 @@ describe('client/server integration', () => {
                     statusCode: 404,
                     body: { error: 'page not found' },
                     message: '{"error":"page not found"}',
+                    meta: null,
                     name: 'FetchrError',
+                    output: null,
                     rawRequest: {
                         url: 'http://localhost:3000/non-existent/item',
                         method: 'GET',
@@ -237,8 +242,11 @@ describe('client/server integration', () => {
                 });
 
                 expect(response).to.deep.equal({
+                    body: null,
                     message: 'The user aborted a request.',
+                    meta: null,
                     name: 'FetchrError',
+                    output: null,
                     statusCode: 0,
                     rawRequest: {
                         url: 'http://localhost:3000/api/error;error=timeout',
@@ -279,8 +287,11 @@ describe('client/server integration', () => {
                 });
 
                 expect(response).to.deep.equal({
+                    body: null,
                     message: 'Failed to fetch',
+                    meta: null,
                     name: 'FetchrError',
+                    output: null,
                     statusCode: 0,
                     rawRequest: {
                         url: 'http://localhost:3001/error',
@@ -365,7 +376,9 @@ describe('client/server integration', () => {
                 expect(response).to.deep.equal({
                     body: { error: 'page not found' },
                     message: '{"error":"page not found"}',
+                    meta: null,
                     name: 'FetchrError',
+                    output: null,
                     rawRequest: {
                         url: 'http://localhost:3000/non-existent/item',
                         method: 'POST',
@@ -391,8 +404,11 @@ describe('client/server integration', () => {
                 });
 
                 expect(response).to.deep.equal({
+                    body: null,
                     message: 'The user aborted a request.',
+                    meta: null,
                     name: 'FetchrError',
+                    output: null,
                     rawRequest: {
                         url: 'http://localhost:3000/api/error',
                         method: 'POST',

--- a/tests/functional/fetchr.test.js
+++ b/tests/functional/fetchr.test.js
@@ -139,6 +139,8 @@ describe('client/server integration', () => {
                 });
 
                 expect(response).to.deep.equal({
+                    message: 'Failed to fetch',
+                    name: 'FetchrError',
                     statusCode: 0,
                     rawRequest: {
                         url: 'http://localhost:3001/error',
@@ -161,7 +163,10 @@ describe('client/server integration', () => {
                         output: { message: 'error' },
                         meta: { foo: 'bar' },
                     },
+                    message:
+                        '{"output":{"message":"error"},"meta":{"foo":"bar"}}',
                     meta: { foo: 'bar' },
+                    name: 'FetchrError',
                     output: { message: 'error' },
                     rawRequest: {
                         url: 'http://localhost:3000/api/error',
@@ -187,7 +192,9 @@ describe('client/server integration', () => {
                         output: { message: 'unexpected' },
                         meta: {},
                     },
+                    message: '{"output":{"message":"unexpected"},"meta":{}}',
                     meta: {},
+                    name: 'FetchrError',
                     output: { message: 'unexpected' },
                     rawRequest: {
                         url: 'http://localhost:3000/api/error;error=unexpected',
@@ -209,6 +216,8 @@ describe('client/server integration', () => {
                 expect(response).to.deep.equal({
                     statusCode: 404,
                     body: { error: 'page not found' },
+                    message: '{"error":"page not found"}',
+                    name: 'FetchrError',
                     rawRequest: {
                         url: 'http://localhost:3000/non-existent/item',
                         method: 'GET',
@@ -228,6 +237,8 @@ describe('client/server integration', () => {
                 });
 
                 expect(response).to.deep.equal({
+                    message: 'The user aborted a request.',
+                    name: 'FetchrError',
                     statusCode: 0,
                     rawRequest: {
                         url: 'http://localhost:3000/api/error;error=timeout',
@@ -268,6 +279,8 @@ describe('client/server integration', () => {
                 });
 
                 expect(response).to.deep.equal({
+                    message: 'Failed to fetch',
+                    name: 'FetchrError',
                     statusCode: 0,
                     rawRequest: {
                         url: 'http://localhost:3001/error',
@@ -293,7 +306,10 @@ describe('client/server integration', () => {
                         output: { message: 'error' },
                         meta: { foo: 'bar' },
                     },
+                    message:
+                        '{"output":{"message":"error"},"meta":{"foo":"bar"}}',
                     meta: { foo: 'bar' },
+                    name: 'FetchrError',
                     output: { message: 'error' },
                     rawRequest: {
                         url: 'http://localhost:3000/api/error',
@@ -322,7 +338,9 @@ describe('client/server integration', () => {
                         output: { message: 'unexpected' },
                         meta: {},
                     },
+                    message: '{"output":{"message":"unexpected"},"meta":{}}',
                     meta: {},
+                    name: 'FetchrError',
                     output: { message: 'unexpected' },
                     rawRequest: {
                         url: 'http://localhost:3000/api/error',
@@ -345,8 +363,9 @@ describe('client/server integration', () => {
                 });
 
                 expect(response).to.deep.equal({
-                    statusCode: 404,
                     body: { error: 'page not found' },
+                    message: '{"error":"page not found"}',
+                    name: 'FetchrError',
                     rawRequest: {
                         url: 'http://localhost:3000/non-existent/item',
                         method: 'POST',
@@ -355,6 +374,7 @@ describe('client/server integration', () => {
                             'X-Requested-With': 'XMLHttpRequest',
                         },
                     },
+                    statusCode: 404,
                     url: 'http://localhost:3000/non-existent/item',
                     timeout: 3000,
                 });
@@ -371,7 +391,8 @@ describe('client/server integration', () => {
                 });
 
                 expect(response).to.deep.equal({
-                    statusCode: 0,
+                    message: 'The user aborted a request.',
+                    name: 'FetchrError',
                     rawRequest: {
                         url: 'http://localhost:3000/api/error',
                         method: 'POST',
@@ -380,6 +401,7 @@ describe('client/server integration', () => {
                             'X-Requested-With': 'XMLHttpRequest',
                         },
                     },
+                    statusCode: 0,
                     url: 'http://localhost:3000/api/error',
                     timeout: 20,
                 });

--- a/tests/util/testCrud.js
+++ b/tests/util/testCrud.js
@@ -117,9 +117,8 @@ module.exports = function testCrud(
                 };
                 var allowFailure = function (done) {
                     return function (err) {
-                        expect(err.name).to.equal('Error');
+                        expect(err.name).to.equal('FetchrError');
                         expect(err.message).to.exist;
-                        expect(err.stack).to.exist;
                         done();
                     };
                 };
@@ -209,9 +208,8 @@ module.exports = function testCrud(
                     if (!err) {
                         done(new Error('This operation should have failed'));
                     } else {
-                        expect(err.name).to.equal('Error');
+                        expect(err.name).to.equal('FetchrError');
                         expect(err.message).to.exist;
-                        expect(err.stack).to.exist;
                         done();
                     }
                 };
@@ -404,7 +402,7 @@ module.exports = function testCrud(
                 .read(mockNoopService.resource)
                 .clientConfig(config)
                 .end(function (err) {
-                    expect(err.name).to.equal('Error');
+                    expect(err.name).to.equal('FetchrError');
                     expect(err.message).to.contain(
                         'operation: read is undefined on service: mock_noop_service'
                     );
@@ -418,7 +416,7 @@ module.exports = function testCrud(
                 .clientConfig(config)
                 .end()
                 .catch(function (err) {
-                    expect(err.name).to.equal('Error');
+                    expect(err.name).to.equal('FetchrError');
                     expect(err.message).to.contain(
                         'operation: read is undefined on service: mock_noop_service'
                     );


### PR DESCRIPTION
After migrating from xhr to native fetch, many cases inside `FetchrError` were not reachable anymore. I didn't refactor it back that time since the code was super hard to understand and we didn't have functional tests to see the real consequences of updating it. But now it was a breeze.

Hopefully, FetchrError class is easier to understand now. I also briefly document it in the README and, as you can see, the data inside the error could be better and simplified. But it would introduce some breaking changes that I would postpone for V1 now.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
