### PR TITLE
fix: allow requests to be aborted after retries and timeouts

### DIFF
--- a/libs/util/httpRequest.js
+++ b/libs/util/httpRequest.js
@@ -108,7 +108,20 @@ function httpRequest(options) {
     var controller = new AbortController();
     var currentAttempt = 0;
 
-    var promise = io(options, controller).catch(function retry(err) {
+    // handleError is the onReject promise callback that we attach to
+    // the io call (ex. io().catch(handleError)). Since io is a
+    // promise and since we must be able to retry requests (aka call
+    // io function again), we must call io from within
+    // handleError. This means that handleError is a recursive
+    // function. Recursive promises are problematic since they can
+    // block the main thread for a while. However, since the inner io
+    // call is wrapped in a setTimeout (through delayPromise) we are
+    // safe here.
+    //
+    // The call flow:
+    //
+    // httpRequest -> io -> handleError -> io -> handleError -> end
+    function handleError(err) {
         if (!shouldRetry(err, options, currentAttempt)) {
             throw err;
         }
@@ -124,13 +137,22 @@ function httpRequest(options) {
         controller = new AbortController();
         currentAttempt += 1;
         return delayPromise(function () {
-            return io(options, controller).catch(retry);
+            return io(options, controller).catch(handleError);
         }, delay);
-    });
+    }
+
+    var promise = io(options, controller).catch(handleError);
 
     return {
         then: promise.then.bind(promise),
         catch: promise.catch.bind(promise),
+
+        // Differently from then and catch, we must wrap
+        // controller.abort in our own function to make sure that we
+        // have a fresh reference to the current AbortController being
+        // used. If we don't do it, controller will point to the first
+        // request, preventing users to abort subsequent requests in
+        // case of retries.
         abort: function () {
             return controller.abort();
         },

--- a/tests/functional/app.js
+++ b/tests/functional/app.js
@@ -5,11 +5,13 @@ const { itemsService } = require('./resources/item');
 const { errorsService } = require('./resources/error');
 const { headersService } = require('./resources/headers');
 const { alwaysSlowService } = require('./resources/alwaysSlow');
+const { slowThenFastService } = require('./resources/slowThenFast');
 
 Fetchr.registerService(itemsService);
 Fetchr.registerService(errorsService);
 Fetchr.registerService(headersService);
 Fetchr.registerService(alwaysSlowService);
+Fetchr.registerService(slowThenFastService);
 
 const app = express();
 

--- a/tests/functional/app.js
+++ b/tests/functional/app.js
@@ -4,11 +4,12 @@ const Fetchr = require('../../libs/fetcher');
 const { itemsService } = require('./resources/item');
 const { errorsService } = require('./resources/error');
 const { headersService } = require('./resources/headers');
-const { slowService } = require('./resources/slow');
+const { alwaysSlowService } = require('./resources/alwaysSlow');
 
 Fetchr.registerService(itemsService);
 Fetchr.registerService(errorsService);
 Fetchr.registerService(headersService);
+Fetchr.registerService(alwaysSlowService);
 
 const app = express();
 

--- a/tests/functional/fetchr.test.js
+++ b/tests/functional/fetchr.test.js
@@ -266,6 +266,25 @@ describe('client/server integration', () => {
                 });
             });
 
+            it('can abort after a timeout', async () => {
+                const response = await page.evaluate(() => {
+                    const fetcher = new Fetchr({});
+                    const promise = fetcher.read('slow', null, {
+                        retry: { maxRetries: 5, interval: 0 },
+                        timeout: 200,
+                    });
+
+                    return new Promise((resolve) =>
+                        setTimeout(() => {
+                            promise.abort();
+                            resolve();
+                        }, 500)
+                    ).then(() => promise.catch((err) => err));
+                });
+
+                expect(response.reason).to.equal(FetchrError.ABORT);
+            });
+
             it('can handle timeouts', async () => {
                 const response = await page.evaluate(() => {
                     const fetcher = new Fetchr({});

--- a/tests/functional/fetchr.test.js
+++ b/tests/functional/fetchr.test.js
@@ -309,6 +309,22 @@ describe('client/server integration', () => {
                     meta: {},
                 });
             });
+
+            it('can retry timed out requests', async () => {
+                const response = await page.evaluate(() => {
+                    const fetcher = new Fetchr({});
+                    return fetcher
+                        .read('slow-then-fast', { reset: true })
+                        .then(() =>
+                            fetcher.read('slow-then-fast', null, {
+                                retry: { maxRetries: 5 },
+                                timeout: 80,
+                            })
+                        );
+                });
+
+                expect(response.data.attempts).to.equal(3);
+            });
         });
 
         describe('POST', () => {

--- a/tests/functional/fetchr.test.js
+++ b/tests/functional/fetchr.test.js
@@ -267,6 +267,17 @@ describe('client/server integration', () => {
             });
 
             it('can abort after a timeout', async () => {
+                // This test triggers a call to the slow resource
+                // (which always takes 5s to respond) with a timeout
+                // of 200ms. After that, we schedule an abort call
+                // after 500ms (in the middle of the 3rd call).
+
+                // Since the abort and the timeout mechanisms share
+                // the same AbortController instance, this test
+                // assures that after internal abortions (due to the
+                // timeouts) it's still possible to make the user
+                // abort mechanism work.
+
                 const response = await page.evaluate(() => {
                     const fetcher = new Fetchr({});
                     const promise = fetcher.read('slow', null, {
@@ -330,6 +341,12 @@ describe('client/server integration', () => {
             });
 
             it('can retry timed out requests', async () => {
+                // This test makes sure that we are renewing the
+                // AbortController for each new request
+                // attempt. Otherwise, after the first AbortController
+                // is triggered, all the following requests would fail
+                // instantly.
+
                 const response = await page.evaluate(() => {
                     const fetcher = new Fetchr({});
                     return fetcher

--- a/tests/functional/resources/alwaysSlow.js
+++ b/tests/functional/resources/alwaysSlow.js
@@ -1,4 +1,7 @@
-const slowService = {
+// This resource allows us to exercise timeout and abort capacities of
+// the fetchr client.
+
+const alwaysSlowService = {
     resource: 'slow',
     read(req, resource, params, config, callback) {
         setTimeout(() => {
@@ -13,5 +16,5 @@ const slowService = {
 };
 
 module.exports = {
-    slowService,
+    alwaysSlowService,
 };

--- a/tests/functional/resources/slowThenFast.js
+++ b/tests/functional/resources/slowThenFast.js
@@ -1,0 +1,27 @@
+// This resource gives 2 slow responses and then a fast one. This is
+// so, so we can test that fetchr client is able to retry timed out
+// requests.
+
+const state = {
+    count: 0,
+};
+
+const slowThenFastService = {
+    resource: 'slow-then-fast',
+    read(req, resource, params, config, callback) {
+        if (params.reset) {
+            state.count = 0;
+            callback();
+        }
+
+        const timeout = state.count === 2 ? 0 : 5000;
+        state.count++;
+        setTimeout(() => {
+            callback(null, { attempts: state.count });
+        }, timeout);
+    },
+};
+
+module.exports = {
+    slowThenFastService,
+};


### PR DESCRIPTION
If we don't create a new AbortController on every retry, the abort
method will have a reference to the first controller that is already
expired.

We must also pay attention to not use the same controller on every
request, otherwise retries would not be possible.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
