### PR TITLE
feat(client): add support for global retry configuration

### DIFF
--- a/libs/fetcher.client.js
+++ b/libs/fetcher.client.js
@@ -184,7 +184,9 @@ function Fetcher(options) {
         corsPath: options.corsPath,
         context: options.context || {},
         contextPicker: options.contextPicker || {},
+        retry: options.retry || null,
         statsCollector: options.statsCollector,
+        unsafeAllowRetry: Boolean(options.unsafeAllowRetry),
         _serviceMeta: this._serviceMeta,
     };
 }

--- a/tests/unit/libs/fetcher.client.js
+++ b/tests/unit/libs/fetcher.client.js
@@ -649,4 +649,83 @@ describe('Client Fetcher', function () {
             });
         });
     });
+
+    describe('Custom retry', function () {
+        describe('should be configurable globally', function () {
+            before(function () {
+                mockery.registerMock('./util/httpRequest', function (options) {
+                    expect(options.retry).to.deep.equal({
+                        interval: 350,
+                        maxRetries: 2,
+                        retryOnPost: true,
+                        statusCodes: [0, 502, 504],
+                    });
+                    return httpRequest(options);
+                });
+                mockery.enable({
+                    useCleanCache: true,
+                    warnOnUnregistered: false,
+                });
+
+                Fetcher = require('../../../libs/fetcher.client');
+
+                this.fetcher = new Fetcher({
+                    retry: {
+                        interval: 350,
+                        maxRetries: 2,
+                        statusCodes: [0, 502, 504],
+                    },
+                    unsafeAllowRetry: true,
+                });
+            });
+
+            testCrud(params, body, config, callback, resolve, reject);
+
+            after(function () {
+                mockery.deregisterMock('./util/httpRequest');
+                mockery.disable();
+            });
+        });
+
+        describe('should be configurable per request', function () {
+            before(function () {
+                mockery.registerMock('./util/httpRequest', function (options) {
+                    expect(options.retry).to.deep.equal({
+                        interval: 350,
+                        maxRetries: 2,
+                        retryOnPost: true,
+                        statusCodes: [0, 502, 504],
+                    });
+                    return httpRequest(options);
+                });
+                mockery.enable({
+                    useCleanCache: true,
+                    warnOnUnregistered: false,
+                });
+                Fetcher = require('../../../libs/fetcher.client');
+                this.fetcher = new Fetcher({});
+            });
+            var customConfig = {
+                retry: {
+                    interval: 350,
+                    maxRetries: 2,
+                    statusCodes: [0, 502, 504],
+                },
+                unsafeAllowRetry: true,
+            };
+            testCrud({
+                disableNoConfigTests: true,
+                params: params,
+                body: body,
+                config: customConfig,
+                callback: callback,
+                resolve: resolve,
+                reject: reject,
+            });
+            after(function () {
+                mockery.deregisterMock('./util/httpRequest');
+                mockery.disable();
+            });
+        });
+    });
 });


### PR DESCRIPTION
@redonkulus we were only able to set retry configuration per request. Now, it's possible to set some (or all) configuration globally:

```js
const fetchr = new Fetchr({
    retry: {
     interval: 350,
     statusCodes: [0, 502, 504],
   },
});

fetchr.read('resource').clientConfig({ retry: { maxRetries: 2 } }).end();
```

This avoids repeating some configuration that (at least in our case) are always the same.



<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
