### PR TITLE
tests: always use node-fetch to simulate browser fetch

### DIFF
--- a/tests/unit/setup.js
+++ b/tests/unit/setup.js
@@ -14,10 +14,8 @@ const { fetch, Request } = abortableFetch({
     Request: nodeFetch.Request,
 });
 
-if (!global.fetch) {
-    global.AbortController = AbortController;
-    global.Headers = nodeFetch.Headers;
-    global.Request = Request;
-    global.Response = nodeFetch.Response;
-    global.fetch = fetch;
-}
+global.AbortController = AbortController;
+global.Headers = nodeFetch.Headers;
+global.Request = Request;
+global.Response = nodeFetch.Response;
+global.fetch = fetch;


### PR DESCRIPTION
Since `httpRequest` is only used in the browser, it doesn't matter much if we are using `node-fetch`, `isomorphic-fetch`, `undici` or node's native fetch. Said that, to avoid tests to fail on Node 18 (which includes a native fetch implementation), we can overwrite the global fetch with node-fetch's implementation.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
