### PR TITLE
fix: make options optional in fetchr client just as in server

### DIFF
--- a/libs/fetcher.client.js
+++ b/libs/fetcher.client.js
@@ -174,19 +174,19 @@ Request.prototype.end = function (callback) {
  *      the stats object, which contains resource, operation, params (request params),
  *      statusCode, err, and time (elapsed time)
  */
-
 function Fetcher(options) {
+    var opts = options || {};
     this._serviceMeta = [];
     this.options = {
-        headers: options.headers,
-        xhrPath: options.xhrPath || DEFAULT_PATH,
-        xhrTimeout: options.xhrTimeout || DEFAULT_TIMEOUT,
-        corsPath: options.corsPath,
-        context: options.context || {},
-        contextPicker: options.contextPicker || {},
-        retry: options.retry || null,
-        statsCollector: options.statsCollector,
-        unsafeAllowRetry: Boolean(options.unsafeAllowRetry),
+        headers: opts.headers,
+        xhrPath: opts.xhrPath || DEFAULT_PATH,
+        xhrTimeout: opts.xhrTimeout || DEFAULT_TIMEOUT,
+        corsPath: opts.corsPath,
+        context: opts.context || {},
+        contextPicker: opts.contextPicker || {},
+        retry: opts.retry || null,
+        statsCollector: opts.statsCollector,
+        unsafeAllowRetry: Boolean(opts.unsafeAllowRetry),
         _serviceMeta: this._serviceMeta,
     };
 }


### PR DESCRIPTION
In the server Fetchr, the options passed to the constructor are optional and we then use default values.

That was not the same in the client Fetchr.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
