### PR TITLE
feat: make Request object thenable

### DIFF
--- a/libs/fetcher.client.js
+++ b/libs/fetcher.client.js
@@ -104,6 +104,24 @@ Request.prototype._captureMetaAndStats = function (err, result) {
     }
 };
 
+Request.prototype.then = function (resolve, reject) {
+    return this.end(function (err, data, meta) {
+        if (err) {
+            reject(err);
+        } else {
+            resolve({ data, meta });
+        }
+    });
+};
+
+Request.prototype.catch = function (reject) {
+    return this.end(function (err) {
+        if (err) {
+            reject(err);
+        }
+    });
+};
+
 /**
  * Execute this fetcher request and call callback.
  * @method end
@@ -112,6 +130,12 @@ Request.prototype._captureMetaAndStats = function (err, result) {
  * @async
  */
 Request.prototype.end = function (callback) {
+    if (!callback) {
+        console.warn(
+            'You called .end() without a callback. This will become an error in the future. Use .then() instead.',
+        );
+    }
+
     var self = this;
     self._startTime = Date.now();
 

--- a/libs/fetcher.client.js
+++ b/libs/fetcher.client.js
@@ -143,7 +143,7 @@ Request.prototype.end = function (callback) {
  * @class FetcherClient
  * @param {Object} options configuration options for Fetcher
  * @param {String} [options.xhrPath="/api"] The path for requests
- * @param {Number} [options.xhrTimout=3000] Timeout in milliseconds for all requests
+ * @param {Number} [options.xhrTimeout=3000] Timeout in milliseconds for all requests
  * @param {Boolean} [options.corsPath] Base CORS path in case CORS is enabled
  * @param {Object} [options.context] The context object that is propagated to all outgoing
  *      requests as query params.  It can contain current-session/context data that should

--- a/libs/fetcher.js
+++ b/libs/fetcher.js
@@ -226,6 +226,12 @@ class Request {
      * is complete.
      */
     end(callback) {
+        if (!callback) {
+            console.warn(
+                'You called .end() without a callback. This will become an error in the future. Use .then() instead.',
+            );
+        }
+
         this._startTime = Date.now();
 
         const promise = new Promise((resolve, reject) => {
@@ -253,6 +259,24 @@ class Request {
         } else {
             return promise;
         }
+    }
+
+    then(resolve, reject) {
+        return this.end((err, data, meta) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve({ data, meta });
+            }
+        });
+    }
+
+    catch(reject) {
+        return this.end((err) => {
+            if (err) {
+                reject(err);
+            }
+        });
     }
 }
 

--- a/libs/util/httpRequest.js
+++ b/libs/util/httpRequest.js
@@ -9,7 +9,7 @@
 
 var FetchrError = require('./FetchrError');
 
-function shouldRetry(err, options, attempt) {
+function _shouldRetry(err, options, attempt) {
     if (err.reason === FetchrError.ABORT) {
         return false;
     }
@@ -121,7 +121,7 @@ function httpRequest(options) {
     //
     // httpRequest -> _fetch -> _retry -> _fetch -> _retry -> end
     function _retry(err) {
-        if (!shouldRetry(err, options, currentAttempt)) {
+        if (!_shouldRetry(err, options, currentAttempt)) {
             throw err;
         }
 

--- a/libs/util/httpRequest.js
+++ b/libs/util/httpRequest.js
@@ -33,7 +33,7 @@ function delayPromise(fn, delay) {
     });
 }
 
-function io(options, controller) {
+function _fetch(options, controller) {
     var timedOut = false;
     var request = new Request(options.url, {
         body: options.body,
@@ -137,11 +137,11 @@ function httpRequest(options) {
         controller = new AbortController();
         currentAttempt += 1;
         return delayPromise(function () {
-            return io(options, controller).catch(handleError);
+            return _fetch(options, controller).catch(handleError);
         }, delay);
     }
 
-    var promise = io(options, controller).catch(handleError);
+    var promise = _fetch(options, controller).catch(handleError);
 
     return {
         then: promise.then.bind(promise),

--- a/libs/util/httpRequest.js
+++ b/libs/util/httpRequest.js
@@ -9,148 +9,161 @@
 
 var FetchrError = require('./FetchrError');
 
-function _shouldRetry(err, options, attempt) {
+function _shouldRetry(err) {
     if (err.reason === FetchrError.ABORT) {
         return false;
     }
 
-    if (attempt >= options.retry.maxRetries) {
+    if (this._currentAttempt >= this._options.retry.maxRetries) {
         return false;
     }
 
-    if (options.method === 'POST' && !options.retry.retryOnPost) {
+    if (this._options.method === 'POST' && !this._options.retry.retryOnPost) {
         return false;
     }
 
-    return options.retry.statusCodes.indexOf(err.statusCode) !== -1;
+    return this._options.retry.statusCodes.indexOf(err.statusCode) !== -1;
 }
 
-function _fetch(options, controller) {
+// _retry is the onReject promise callback that we attach to the
+// _fetch call (ex. _fetch().catch(_retry)). Since _fetch is a promise
+// and since we must be able to retry requests (aka call _fetch
+// function again), we must call _fetch from within _retry. This means
+// that _fetch is a recursive function. Recursive promises are
+// problematic since they can block the main thread for a
+// while. However, since the inner _fetch call is wrapped in a
+// setTimeout we are safe here.
+//
+// The call flow:
+//
+// send -> _fetch -> _retry -> _fetch -> _retry -> end
+function _retry(err) {
+    var self = this;
+    if (!_shouldRetry.call(self, err)) {
+        throw err;
+    }
+
+    // Use exponential backoff and full jitter
+    // strategy published in
+    // https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+    var delay =
+        Math.random() *
+        self._options.retry.interval *
+        Math.pow(2, self._currentAttempt);
+
+    self._controller = new AbortController();
+    self._currentAttempt += 1;
+
+    return new Promise(function (resolve, reject) {
+        setTimeout(function () {
+            _fetch.call(self).then(resolve, reject);
+        }, delay);
+    });
+}
+
+function _fetch() {
+    var self = this;
     var timedOut = false;
-    var request = new Request(options.url, {
-        body: options.body,
-        credentials: options.credentials,
-        headers: options.headers,
-        method: options.method,
-        signal: controller.signal,
+    var request = new Request(self._options.url, {
+        body: self._options.body,
+        credentials: self._options.credentials,
+        headers: self._options.headers,
+        method: self._options.method,
+        signal: self._controller.signal,
     });
 
     var timeoutId = setTimeout(function () {
         timedOut = true;
-        controller.abort();
-    }, options.timeout);
+        self._controller.abort();
+    }, self._options.timeout);
 
-    return fetch(request).then(
-        function (response) {
-            clearTimeout(timeoutId);
+    return fetch(request)
+        .then(
+            function (response) {
+                clearTimeout(timeoutId);
 
-            if (response.ok) {
-                return response.json().catch(function () {
+                if (response.ok) {
+                    return response.json().catch(function () {
+                        throw new FetchrError(
+                            FetchrError.BAD_JSON,
+                            'Cannot parse response into a JSON object',
+                            self._options,
+                            request,
+                            response,
+                        );
+                    });
+                } else {
+                    return response.text().then(function (message) {
+                        throw new FetchrError(
+                            FetchrError.BAD_HTTP_STATUS,
+                            message,
+                            self._options,
+                            request,
+                            response,
+                        );
+                    });
+                }
+            },
+            function (err) {
+                clearTimeout(timeoutId);
+                if (err.name === 'AbortError') {
+                    if (timedOut) {
+                        throw new FetchrError(
+                            FetchrError.TIMEOUT,
+                            'Request failed due to timeout',
+                            self._options,
+                            request,
+                        );
+                    }
+
                     throw new FetchrError(
-                        FetchrError.BAD_JSON,
-                        'Cannot parse response into a JSON object',
-                        options,
-                        request,
-                        response,
-                    );
-                });
-            } else {
-                return response.text().then(function (message) {
-                    throw new FetchrError(
-                        FetchrError.BAD_HTTP_STATUS,
-                        message,
-                        options,
-                        request,
-                        response,
-                    );
-                });
-            }
-        },
-        function (err) {
-            clearTimeout(timeoutId);
-            if (err.name === 'AbortError') {
-                if (timedOut) {
-                    throw new FetchrError(
-                        FetchrError.TIMEOUT,
-                        'Request failed due to timeout',
-                        options,
+                        FetchrError.ABORT,
+                        err.message,
+                        self._options,
                         request,
                     );
                 }
 
                 throw new FetchrError(
-                    FetchrError.ABORT,
+                    FetchrError.UNKNOWN,
                     err.message,
-                    options,
+                    self._options,
                     request,
                 );
-            }
-
-            throw new FetchrError(
-                FetchrError.UNKNOWN,
-                err.message,
-                options,
-                request,
-            );
-        },
-    );
+            },
+        )
+        .catch(_retry.bind(self));
 }
 
+function _send() {
+    this._promise = _fetch.call(this);
+}
+
+function FetchrHttpRequest(options) {
+    this._controller = new AbortController();
+    this._currentAttempt = 0;
+    this._options = options;
+    this._promise = null;
+}
+
+FetchrHttpRequest.prototype.abort = function () {
+    return this._controller.abort();
+};
+
+FetchrHttpRequest.prototype.then = function (resolve, reject) {
+    this._promise = this._promise.then(resolve, reject);
+    return this;
+};
+
+FetchrHttpRequest.prototype.catch = function (reject) {
+    this._promise = this._promise.catch(reject);
+    return this;
+};
+
 function httpRequest(options) {
-    var controller = new AbortController();
-    var currentAttempt = 0;
-
-    // _retry is the onReject promise callback that we attach to the
-    // _fetch call (ex. _fetch().catch(_retry)). Since _fetch is a
-    // promise and since we must be able to retry requests (aka call
-    // _fetch function again), we must call _fetch from within
-    // _retry. This means that _fetch is a recursive
-    // function. Recursive promises are problematic since they can
-    // block the main thread for a while. However, since the inner
-    // _fetch call is wrapped in a setTimeout we are safe here.
-    //
-    // The call flow:
-    //
-    // httpRequest -> _fetch -> _retry -> _fetch -> _retry -> end
-    function _retry(err) {
-        if (!_shouldRetry(err, options, currentAttempt)) {
-            throw err;
-        }
-
-        // Use exponential backoff and full jitter
-        // strategy published in
-        // https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
-        var delay =
-            Math.random() *
-            options.retry.interval *
-            Math.pow(2, currentAttempt);
-
-        controller = new AbortController();
-        currentAttempt += 1;
-
-        return new Promise(function (resolve, reject) {
-            setTimeout(function () {
-                _fetch(options, controller).catch(_retry).then(resolve, reject);
-            }, delay);
-        });
-    }
-
-    var promise = _fetch(options, controller).catch(_retry);
-
-    return {
-        then: promise.then.bind(promise),
-        catch: promise.catch.bind(promise),
-
-        // Differently from then and catch, we must wrap
-        // controller.abort in our own function to make sure that we
-        // have a fresh reference to the current AbortController being
-        // used. If we don't do it, controller will point to the first
-        // request, preventing users to abort subsequent requests in
-        // case of retries.
-        abort: function () {
-            return controller.abort();
-        },
-    };
+    var request = new FetchrHttpRequest(options);
+    _send.call(request);
+    return request;
 }
 
 module.exports = httpRequest;

--- a/libs/util/httpRequest.js
+++ b/libs/util/httpRequest.js
@@ -25,14 +25,6 @@ function _shouldRetry(err, options, attempt) {
     return options.retry.statusCodes.indexOf(err.statusCode) !== -1;
 }
 
-function delayPromise(fn, delay) {
-    return new Promise(function (resolve, reject) {
-        setTimeout(function () {
-            fn().then(resolve, reject);
-        }, delay);
-    });
-}
-
 function _fetch(options, controller) {
     var timedOut = false;
     var request = new Request(options.url, {
@@ -135,9 +127,12 @@ function httpRequest(options) {
 
         controller = new AbortController();
         currentAttempt += 1;
-        return delayPromise(function () {
-            return _fetch(options, controller).catch(handleError);
-        }, delay);
+
+        return new Promise(function (resolve, reject) {
+            setTimeout(function () {
+                _fetch(options, controller).catch(_retry).then(resolve, reject);
+            }, delay);
+        });
     }
 
     var promise = _fetch(options, controller).catch(_retry);

--- a/tests/util/testCrud.js
+++ b/tests/util/testCrud.js
@@ -70,7 +70,6 @@ module.exports = function testCrud(
                         .params(params)
                         .body(body)
                         .clientConfig(config)
-                        .end()
                         .then(
                             resolve(operation, done),
                             reject(operation, done),
@@ -81,7 +80,6 @@ module.exports = function testCrud(
                     this.fetcher[operation](resource)
                         .params(params)
                         .clientConfig(config)
-                        .end()
                         .then(
                             resolve(operation, done),
                             reject(operation, done),
@@ -93,7 +91,6 @@ module.exports = function testCrud(
                         .params(params)
                         .body(body)
                         .clientConfig(config)
-                        .end()
                         .then(
                             resolve(operation, done),
                             reject(operation, done),
@@ -104,7 +101,6 @@ module.exports = function testCrud(
                     this.fetcher[operation](resource)
                         .params(params)
                         .clientConfig(config)
-                        .end()
                         .then(
                             resolve(operation, done),
                             reject(operation, done),
@@ -128,7 +124,6 @@ module.exports = function testCrud(
                         .params(params)
                         .body(body)
                         .clientConfig(config)
-                        .end()
                         .then(denySuccess(done), allowFailure(done));
                 });
                 it('should reject a READ promise on invalid resource', function (done) {
@@ -136,7 +131,6 @@ module.exports = function testCrud(
                     this.fetcher[operation](invalidResource)
                         .params(params)
                         .clientConfig(config)
-                        .end()
                         .then(denySuccess(done), allowFailure(done));
                 });
                 it('should reject a UPDATE promise on invalid resource', function (done) {
@@ -145,7 +139,6 @@ module.exports = function testCrud(
                         .params(params)
                         .body(body)
                         .clientConfig(config)
-                        .end()
                         .then(denySuccess(done), allowFailure(done));
                 });
                 it('should reject a DELETE promise on invalid resource', function (done) {
@@ -153,7 +146,6 @@ module.exports = function testCrud(
                     this.fetcher[operation](invalidResource)
                         .params(params)
                         .clientConfig(config)
-                        .end()
                         .then(denySuccess(done), allowFailure(done));
                 });
                 it('should throw if no resource is given', function () {
@@ -377,7 +369,6 @@ module.exports = function testCrud(
                         meta: { headers: { 'x-foo': 'foo' } },
                     })
                     .clientConfig(config)
-                    .end()
                     .catch(function (err) {
                         if (err) {
                             var serviceMeta = fetcher.getServiceMeta();
@@ -414,7 +405,6 @@ module.exports = function testCrud(
             fetcher
                 .read(mockNoopService.resource)
                 .clientConfig(config)
-                .end()
                 .catch(function (err) {
                     expect(err.name).to.equal('FetchrError');
                     expect(err.message).to.contain(


### PR DESCRIPTION
Now the request object returned by fetchr crud methods are [thenable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables) by default. 

To make it possible, I had to refactor `httpRequest` to transform it in a class to make it easier to expose `then`, `catch` and `abort` to the users. By doing it, it was also possible to simplify the `Request` class and remove some workarounds related to `abort`.

This PR also implement some of the stuff we discussed in https://github.com/yahoo/fetchr/pull/263#issuecomment-881089203 without the need for a major version bump. 

## Before
```js
// superagent style
fetchr
  .read('foo')
  .end()
  .then()

// callback style without callback
fetchr
  .read('foo', null) // passing a second params was necessary to not trigger the superagent API.
  .then() 
```
## After
```js
// superagent or callback
fetchr
  .read('foo')
  .then()
```

This is also quite nice when doing fire and forget calls with async/await:

```js
await fetchr.update('counter');
```

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
