### PR TITLE
fix: always return the same value when resolving requests multiple times

### DIFF
--- a/libs/fetcher.client.js
+++ b/libs/fetcher.client.js
@@ -130,7 +130,7 @@ Request.prototype.catch = function (reject) {
  * @async
  */
 Request.prototype.end = function (callback) {
-    if (!callback) {
+    if (!arguments.length) {
         console.warn(
             'You called .end() without a callback. This will become an error in the future. Use .then() instead.',
         );

--- a/libs/fetcher.js
+++ b/libs/fetcher.js
@@ -226,7 +226,7 @@ class Request {
      * is complete.
      */
     end(callback) {
-        if (!callback) {
+        if (!arguments.length) {
             console.warn(
                 'You called .end() without a callback. This will become an error in the future. Use .then() instead.',
             );

--- a/libs/util/httpRequest.js
+++ b/libs/util/httpRequest.js
@@ -136,14 +136,14 @@ function _fetch() {
 }
 
 function _send() {
-    this._promise = _fetch.call(this);
+    this._request = _fetch.call(this);
 }
 
 function FetchrHttpRequest(options) {
     this._controller = new AbortController();
     this._currentAttempt = 0;
     this._options = options;
-    this._promise = null;
+    this._request = null;
 }
 
 FetchrHttpRequest.prototype.abort = function () {
@@ -151,12 +151,12 @@ FetchrHttpRequest.prototype.abort = function () {
 };
 
 FetchrHttpRequest.prototype.then = function (resolve, reject) {
-    this._promise = this._promise.then(resolve, reject);
+    this._request = this._request.then(resolve, reject);
     return this;
 };
 
 FetchrHttpRequest.prototype.catch = function (reject) {
-    this._promise = this._promise.catch(reject);
+    this._request = this._request.catch(reject);
     return this;
 };
 

--- a/libs/util/httpRequest.js
+++ b/libs/util/httpRequest.js
@@ -151,13 +151,11 @@ FetchrHttpRequest.prototype.abort = function () {
 };
 
 FetchrHttpRequest.prototype.then = function (resolve, reject) {
-    this._request = this._request.then(resolve, reject);
-    return this;
+    return this._request.then(resolve, reject);
 };
 
 FetchrHttpRequest.prototype.catch = function (reject) {
-    this._request = this._request.catch(reject);
-    return this;
+    return this._request.catch(reject);
 };
 
 function httpRequest(options) {

--- a/tests/unit/libs/util/httpRequest.js
+++ b/tests/unit/libs/util/httpRequest.js
@@ -443,4 +443,29 @@ describe('Client HTTP', function () {
             });
         });
     });
+
+    describe('Promise Support', () => {
+        it('always returns the response if resolved multiple times', async function () {
+            const body = { data: 'BODY' };
+
+            fetchMock.get('/url', { body, status: responseStatus });
+
+            const request = httpRequest(GETConfig);
+
+            expect(await request).to.deep.equal(body);
+            expect(await request).to.deep.equal(body);
+        });
+
+        it('works with Promise.all', function () {
+            const body = { data: 'BODY' };
+
+            fetchMock.get('/url', { body, status: responseStatus });
+
+            const request = httpRequest(GETConfig);
+
+            return Promise.all([request]).then(([result]) => {
+                expect(result).to.deep.equal(body);
+            });
+        });
+    });
 });


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

I found a bug in our system where we were resolving the request multiple times. The first time it was resolved it was fine (and so fetchr tests), but the second time it would resolve with an undefined value. The code was looking something like this:

```js
const request = fetchr.read('foo', { bar: 42 }); // request was triggered
track(request); // would call then internally
return request; // the consumer of this function would also call then
```

Fixing it was simple, we just had to keep the reference to fetch promise in `httpRequest` and always return `_request.then` in `FetchrHttpRequest.then` method.

However, that broke the abort support since we were not return an instance of `FetchrHttpRequest` anymore to the caller. To solve that, it was also necessary to store a reference to `FetchrHttpRequest` in the `Request` class in `fetchr.client.js`.

I added a bunch of more tests to cover this and other cases as well.