### PR TITLE
feat: add support for async based resource operation handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ When an error occurs in your Fetchr CRUD method, you should throw an error objec
 ```js
 export default {
     resource: 'FooService',
-    read: async function create(req, resource, params, configs, callback) {
+    read: async function create(req, resource, params, configs) {
         const err = new Error('it failed');
         err.statusCode = 404;
         err.output = { message: 'Not found', more: 'meta data' };

--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ export default {
     // resource is required
     resource: 'data_service',
     // at least one of the CRUD methods is required
-    read: function (req, resource, params, config, callback) {
-        //...
+    read: async function ({ req, resource, params, config }) {
+        return { data: 'foo' };
     },
     // other methods
-    // create: function(req, resource, params, body, config, callback) {},
-    // update: function(req, resource, params, body, config, callback) {},
-    // delete: function(req, resource, params, config, callback) {}
+    // create: async function({ req, resource, params, body, config }) {},
+    // update: async function({ req, resource, params, body, config }) {},
+    // delete: async function({ req, resource, params, config }) {}
 };
 ```
 
@@ -173,16 +173,16 @@ property of the resolved value.
 // dataService.js
 export default {
     resource: 'data_service',
-    read: function (req, resource, params, config, callback) {
-        // business logic
-        const data = 'response';
-        const meta = {
-            headers: {
-                'cache-control': 'public, max-age=3600',
+    read: async function ({ req, resource, params, config }) {
+        return {
+            data: 'response', // business logic
+            meta: {
+                headers: {
+                    'cache-control': 'public, max-age=3600',
+                },
+                statusCode: 200, // You can even provide a custom statusCode for the fetch response
             },
-            statusCode: 200, // You can even provide a custom statusCode for the fetch response
         };
-        callback(null, data, meta);
     },
 };
 ```
@@ -225,17 +225,17 @@ fetcher.updateOptions({
 
 ## Error Handling
 
-When an error occurs in your Fetchr CRUD method, you should return an error object to the callback. The error object should contain a `statusCode` (default 500) and `output` property that contains a JSON serializable object which will be sent to the client.
+When an error occurs in your Fetchr CRUD method, you should throw an error object. The error object should contain a `statusCode` (default 500) and `output` property that contains a JSON serializable object which will be sent to the client.
 
 ```js
 export default {
     resource: 'FooService',
-    read: function create(req, resource, params, configs, callback) {
+    read: async function create(req, resource, params, configs, callback) {
         const err = new Error('it failed');
         err.statusCode = 404;
         err.output = { message: 'Not found', more: 'meta data' };
         err.meta = { foo: 'bar' };
-        return callback(err);
+        throw err;
     },
 };
 ```

--- a/libs/fetcher.js
+++ b/libs/fetcher.js
@@ -9,12 +9,29 @@ const OP_READ = 'read';
 const OP_CREATE = 'create';
 const OP_UPDATE = 'update';
 const OP_DELETE = 'delete';
+const OPERATIONS = [OP_READ, OP_CREATE, OP_UPDATE, OP_DELETE];
+
 const RESOURCE_SANTIZER_REGEXP = /[^\w.]+/g;
 
 class FetchrError extends Error {
     constructor(message) {
         super(message);
         this.name = 'FetchrError';
+    }
+}
+
+function _checkResourceHandlers(service) {
+    for (const operation of OPERATIONS) {
+        const handler = service[operation];
+        if (!handler) {
+            continue;
+        }
+
+        if (handler.length > 1) {
+            console.warn(
+                `${service.resource} ${operation} handler is callback based. Callback based resource handlers are deprecated and will be removed in the next version.`,
+            );
+        }
     }
 }
 
@@ -392,6 +409,7 @@ class Fetcher {
                 '"resource" property is missing in service definition.',
             );
         }
+        _checkResourceHandlers(service);
 
         Fetcher.services[resource] = service;
         return;

--- a/libs/fetcher.js
+++ b/libs/fetcher.js
@@ -200,24 +200,67 @@ class Request {
      * @param {Object} errData  The error response for failed request
      * @param {Object} result  The response data for successful request
      */
-    _captureMetaAndStats(errData, result) {
-        const meta = (errData && errData.meta) || (result && result.meta);
+    _captureMetaAndStats(err, meta) {
         if (meta) {
             this.serviceMeta.push(meta);
         }
         if (typeof this._statsCollector === 'function') {
-            const err = errData && errData.err;
             this._statsCollector({
                 resource: this.resource,
                 operation: this.operation,
                 params: this._params,
                 statusCode: err
                     ? err.statusCode
-                    : (result && result.meta && result.meta.statusCode) || 200,
+                    : (meta && meta.statusCode) || 200,
                 err,
                 time: Date.now() - this._startTime,
             });
         }
+    }
+
+    /**
+     * Execute this fetcher request
+     * @returns {Promise<FetchrResponse>}
+     */
+    async _executeRequest() {
+        if (!Fetcher.isRegistered(this.resource)) {
+            const err = new FetchrError(
+                `Service "${sanitizeResourceName(this.resource)}" could not be found`,
+            );
+            return { err };
+        }
+
+        const service = Fetcher.getService(this.resource);
+        const handler = service[this.operation];
+
+        if (!handler) {
+            const err = new FetchrError(
+                `operation: ${this.operation} is undefined on service: ${this.resource}`,
+            );
+            return { err };
+        }
+
+        return new Promise((resolve) => {
+            const args = [
+                this.req,
+                this.resource,
+                this._params,
+                this._clientConfig,
+                function executeRequestCallback(err, data, meta) {
+                    resolve({ err, data, meta });
+                },
+            ];
+
+            if (this.operation === OP_CREATE || this.operation === OP_UPDATE) {
+                args.splice(3, 0, this._body);
+            }
+
+            try {
+                handler.apply(service, args);
+            } catch (err) {
+                resolve({ err });
+            }
+        });
     }
 
     /**
@@ -234,31 +277,19 @@ class Request {
 
         this._startTime = Date.now();
 
-        const promise = new Promise((resolve, reject) => {
-            setImmediate(executeRequest, this, resolve, reject);
-        }).then(
-            (result) => {
-                this._captureMetaAndStats(null, result);
-                return result;
-            },
-            (errData) => {
-                this._captureMetaAndStats(errData);
-                throw errData.err;
-            },
-        );
+        return this._executeRequest().then(({ err, data, meta }) => {
+            this._captureMetaAndStats(err, meta);
+            if (callback) {
+                callback(err, data, meta);
+                return;
+            }
 
-        if (callback) {
-            promise.then(
-                (result) => {
-                    setImmediate(callback, null, result.data, result.meta);
-                },
-                (err) => {
-                    setImmediate(callback, err);
-                },
-            );
-        } else {
-            return promise;
-        }
+            if (err) {
+                throw err;
+            }
+
+            return { data, meta };
+        });
     }
 
     then(resolve, reject) {
@@ -277,45 +308,6 @@ class Request {
                 reject(err);
             }
         });
-    }
-}
-
-/**
- * Execute and resolve/reject this fetcher request
- * @param {Object} request Request instance object
- * @param {Function} resolve function to call when request fulfilled
- * @param {Function} reject function to call when request rejected
- */
-function executeRequest(request, resolve, reject) {
-    const args = [
-        request.req,
-        request.resource,
-        request._params,
-        request._clientConfig,
-        function executeRequestCallback(err, data, meta) {
-            if (err) {
-                reject({ err, meta });
-            } else {
-                resolve({ data, meta });
-            }
-        },
-    ];
-
-    const op = request.operation;
-    if (op === OP_CREATE || op === OP_UPDATE) {
-        args.splice(3, 0, request._body);
-    }
-
-    try {
-        const service = Fetcher.getService(request.resource);
-        if (!service[op]) {
-            throw new FetchrError(
-                `operation: ${op} is undefined on service: ${request.resource}`,
-            );
-        }
-        service[op].apply(service, args);
-    } catch (err) {
-        reject({ err });
     }
 }
 
@@ -689,4 +681,12 @@ module.exports = Fetcher;
  * @param {Object} data request result
  * @param {Object} [meta] request meta-data
  * @param {number} [meta.statusCode=200] http status code to return
+ */
+
+/**
+ * @typedef {Object} FetchrResponse
+ * @property {?object} data - Any data returned by the fetchr resource.
+ * @property {?object} meta - Any meta data returned by the fetchr resource.
+ * @property {?Error} err - an error that occurred before, during or
+ * after request was sent.
  */

--- a/libs/fetcher.js
+++ b/libs/fetcher.js
@@ -240,6 +240,20 @@ class Request {
             return { err };
         }
 
+        // async based handler
+        if (handler.length <= 1) {
+            return handler
+                .call(service, {
+                    body: this._body,
+                    config: this._clientConfig,
+                    params: this._params,
+                    req: this.req,
+                    resource: this.resource,
+                })
+                .catch((err) => ({ err }));
+        }
+
+        // callback based handler
         return new Promise((resolve) => {
             const args = [
                 this.req,

--- a/libs/fetcher.js
+++ b/libs/fetcher.js
@@ -485,18 +485,14 @@ following services definitions: ${services}.`);
                 return next(badOperationError(resource, operation));
             }
 
-            const serviceMeta = [];
-
             new Request(operation, resource, {
                 req,
-                serviceMeta,
                 statsCollector,
                 paramsProcessor,
             })
                 .params(params)
                 .body(body)
-                .end((err, data) => {
-                    const meta = serviceMeta[0] || {};
+                .end((err, data, meta = {}) => {
                     if (meta.headers) {
                         res.set(meta.headers);
                     }

--- a/tests/functional/resources/alwaysSlow.js
+++ b/tests/functional/resources/alwaysSlow.js
@@ -1,17 +1,17 @@
+const wait = require('./wait');
+
 // This resource allows us to exercise timeout and abort capacities of
 // the fetchr client.
 
 const alwaysSlowService = {
     resource: 'slow',
-    read(req, resource, params, config, callback) {
-        setTimeout(() => {
-            callback(null, { ok: true });
-        }, 5000);
+    async read() {
+        await wait(5000);
+        return { data: { ok: true } };
     },
-    create(req, resource, params, body, config, callback) {
-        setTimeout(() => {
-            callback(null, { ok: true });
-        }, 5000);
+    async create() {
+        await wait(5000);
+        return { data: { ok: true } };
     },
 };
 

--- a/tests/functional/resources/headers.js
+++ b/tests/functional/resources/headers.js
@@ -1,18 +1,22 @@
 const headersService = {
     resource: 'header',
 
-    read(req, resource, params, config, callback) {
+    async read({ req }) {
         if (req.headers['x-fetchr-request'] !== '42') {
             const err = new Error('missing x-fetchr header');
             err.statusCode = 400;
-            callback(err);
-            return;
+            throw err;
         }
-        callback(
-            null,
-            { headers: 'ok' },
-            { headers: { 'x-fetchr-response': '42' } },
-        );
+        return {
+            data: {
+                headers: 'ok',
+            },
+            meta: {
+                headers: {
+                    'x-fetchr-response': '42',
+                },
+            },
+        };
     },
 };
 

--- a/tests/functional/resources/item.js
+++ b/tests/functional/resources/item.js
@@ -3,51 +3,54 @@ const itemsData = {};
 const itemsService = {
     resource: 'item',
 
-    create(req, resource, params, body, config, callback) {
+    async create({ params, body }) {
         const item = {
             id: params.id,
             value: body.value,
         };
         itemsData[item.id] = item;
-        callback(null, item, { statusCode: 201 });
+        return { data: item, meta: { statusCode: 201 } };
     },
 
-    read(req, resource, params, config, callback) {
+    async read({ params }) {
         if (params.id) {
             const item = itemsData[params.id];
             if (!item) {
                 const err = new Error('not found');
                 err.statusCode = 404;
-                callback(err, null, { foo: 42 });
+                return { err, meta: { foo: 42 } };
             } else {
-                callback(null, item, { statusCode: 200 });
+                return { data: item, meta: { statusCode: 200 } };
             }
         } else {
-            callback(null, Object.values(itemsData), { statusCode: 200 });
+            return {
+                data: Object.values(itemsData),
+                meta: { statusCode: 200 },
+            };
         }
     },
 
-    update(req, resource, params, body, config, callback) {
+    async update({ params, body }) {
         const item = itemsData[params.id];
         if (!item) {
             const err = new Error('not found');
             err.statusCode = 404;
-            callback(err);
+            throw err;
         } else {
             const updatedItem = { ...item, ...body };
             itemsData[params.id] = updatedItem;
-            callback(null, updatedItem, { statusCode: 201 });
+            return { data: updatedItem, meta: { statusCode: 201 } };
         }
     },
 
-    delete(req, resource, params, config, callback) {
+    async delete({ params }) {
         try {
             delete itemsData[params.id];
-            callback(null, null, { statusCode: 200 });
-        } catch (_) {
+            return { data: null, meta: { statusCode: 200 } };
+        } catch {
             const err = new Error('not found');
             err.statusCode = 404;
-            callback(err);
+            throw err;
         }
     },
 };

--- a/tests/functional/resources/slowThenFast.js
+++ b/tests/functional/resources/slowThenFast.js
@@ -1,3 +1,5 @@
+const wait = require('./wait');
+
 // This resource gives 2 slow responses and then a fast one. This is
 // so, so we can test that fetchr client is able to retry timed out
 // requests.
@@ -8,17 +10,18 @@ const state = {
 
 const slowThenFastService = {
     resource: 'slow-then-fast',
-    read(req, resource, params, config, callback) {
+    async read({ params }) {
         if (params.reset) {
             state.count = 0;
-            callback();
+            return {};
         }
 
         const timeout = state.count === 2 ? 0 : 5000;
         state.count++;
-        setTimeout(() => {
-            callback(null, { attempts: state.count });
-        }, timeout);
+
+        await wait(timeout);
+
+        return { data: { attempts: state.count } };
     },
 };
 

--- a/tests/functional/resources/wait.js
+++ b/tests/functional/resources/wait.js
@@ -1,0 +1,3 @@
+module.exports = function wait(time) {
+    return new Promise((resolve) => setTimeout(() => resolve(), time));
+};

--- a/tests/mock/MockErrorService.js
+++ b/tests/mock/MockErrorService.js
@@ -5,22 +5,10 @@
 var MockErrorService = {
     resource: 'mock_error_service',
 
-    // ------------------------------------------------------------------
-    // CRUD Methods
-    // ------------------------------------------------------------------
+    read: async function ({ req, params }) {
+        const meta = this.meta || params.meta;
+        this.meta = null;
 
-    /**
-     * read operation (read as in CRUD).
-     * @method read
-     * @param {Object} req  The request object from connect/express
-     * @param {String} resource  The resource name
-     * @param {Object} params    The parameters identify the resource, and along with information
-     *                           carried in query and matrix parameters in typical REST API
-     * @param {Object} [config={}] The config object.  It can contain "config" for per-request config data.
-     * @param {Fetcher~fetcherCallback} callback callback invoked when fetcher is complete.
-     * @static
-     */
-    read: function (req, resource, params, config, callback) {
         if (
             req.query &&
             req.query.cors &&
@@ -39,87 +27,56 @@ var MockErrorService = {
                 params[key] = value;
             }
         }
-        callback(
-            {
+        return {
+            err: {
                 statusCode: parseInt(params.statusCode),
                 output: params.output,
                 message: params.message,
                 read: 'error',
             },
-            null,
-            this.meta || params.meta,
-        );
-        this.meta = null;
+            data: null,
+            meta,
+        };
     },
-    /**
-     * create operation (create as in CRUD).
-     * @method create
-     * @param {Object} req  The request object from connect/express
-     * @param {String} resource  The resource name
-     * @param {Object} params    The parameters identify the resource, and along with information
-     *                           carried in query and matrix parameters in typical REST API
-     * @param {Object} body      The JSON object that contains the resource data that is being created
-     * @param {Object} [config={}] The config object.  It can contain "config" for per-request config data.
-     * @param {Fetcher~fetcherCallback} callback callback invoked when fetcher is complete.
-     * @static
-     */
-    create: function (req, resource, params, body, config, callback) {
-        callback(
-            {
+
+    create: async function ({ params }) {
+        const meta = this.meta || params.meta;
+        this.meta = null;
+
+        return {
+            err: {
                 statusCode: parseInt(params.statusCode),
                 message: params.message,
                 output: params.output,
                 create: 'error',
             },
-            null,
-            this.meta || params.meta,
-        );
-        this.meta = null;
+            data: null,
+            meta,
+        };
     },
-    /**
-     * update operation (update as in CRUD).
-     * @method update
-     * @param {Object} req  The request object from connect/express
-     * @param {String} resource  The resource name
-     * @param {Object} params    The parameters identify the resource, and along with information
-     *                           carried in query and matrix parameters in typical REST API
-     * @param {Object} body      The JSON object that contains the resource data that is being updated
-     * @param {Object} [config={}] The config object.  It can contain "config" for per-request config data.
-     * @param {Fetcher~fetcherCallback} callback callback invoked when fetcher is complete.
-     * @static
-     */
-    update: function (req, resource, params, body, config, callback) {
-        callback(
-            {
+
+    update: async function ({ params }) {
+        return {
+            err: {
                 statusCode: parseInt(params.statusCode),
                 message: params.message,
                 output: params.output,
                 update: 'error',
             },
-            null,
-        );
+            data: null,
+        };
     },
-    /**
-     * delete operation (delete as in CRUD).
-     * @method delete
-     * @param {Object} req  The request object from connect/express
-     * @param {String} resource  The resource name
-     * @param {Object} params    The parameters identify the resource, and along with information
-     *                           carried in query and matrix parameters in typical REST API
-     * @param {Object} [config={}] The config object.  It can contain "config" for per-request config data.
-     * @param {Fetcher~fetcherCallback} callback callback invoked when fetcher is complete.
-     * @static
-     */
-    delete: function (req, resource, params, config, callback) {
-        callback(
-            {
+
+    delete: async function ({ params }) {
+        return {
+            err: {
                 statusCode: parseInt(params.statusCode),
                 message: params.message,
                 output: params.output,
                 delete: 'error',
             },
-            null,
-        );
+            data: null,
+        };
     },
 };
 

--- a/tests/mock/MockService.js
+++ b/tests/mock/MockService.js
@@ -5,22 +5,10 @@
 var MockService = {
     resource: 'mock_service',
 
-    // ------------------------------------------------------------------
-    // CRUD Methods
-    // ------------------------------------------------------------------
+    read: async function ({ req, resource, params }) {
+        const meta = this.meta || params.meta;
+        this.meta = null;
 
-    /**
-     * read operation (read as in CRUD).
-     * @method read
-     * @param {Object} req  The request object from connect/express
-     * @param {String} resource  The resource name
-     * @param {Object} params    The parameters identify the resource, and along with information
-     *                           carried in query and matrix parameters in typical REST API
-     * @param {Object} [config={}] The config object.  It can contain "config" for per-request config data.
-     * @param {Fetcher~fetcherCallback} callback callback invoked when fetcher is complete.
-     * @static
-     */
-    read: function (req, resource, params, config, callback) {
         if (
             req.query &&
             req.query.cors &&
@@ -39,9 +27,9 @@ var MockService = {
                 params[key] = value;
             }
         }
-        callback(
-            null,
-            {
+
+        return {
+            data: {
                 operation: {
                     name: 'read',
                     success: true,
@@ -51,26 +39,16 @@ var MockService = {
                     params: params,
                 },
             },
-            this.meta || params.meta,
-        );
-        this.meta = null;
+            meta,
+        };
     },
-    /**
-     * create operation (create as in CRUD).
-     * @method create
-     * @param {Object} req  The request object from connect/express
-     * @param {String} resource  The resource name
-     * @param {Object} params    The parameters identify the resource, and along with information
-     *                           carried in query and matrix parameters in typical REST API
-     * @param {Object} body      The JSON object that contains the resource data that is being created
-     * @param {Object} [config={}] The config object.  It can contain "config" for per-request config data.
-     * @param {Fetcher~fetcherCallback} callback callback invoked when fetcher is complete.
-     * @static
-     */
-    create: function (req, resource, params, body, config, callback) {
-        callback(
-            null,
-            {
+
+    create: async function ({ resource, params }) {
+        const meta = this.meta || params.meta;
+        this.meta = null;
+
+        return {
+            data: {
                 operation: {
                     name: 'create',
                     success: true,
@@ -80,26 +58,17 @@ var MockService = {
                     params: params,
                 },
             },
-            this.meta || params.meta,
-        );
-        this.meta = null;
+            err: null,
+            meta,
+        };
     },
-    /**
-     * update operation (update as in CRUD).
-     * @method update
-     * @param {Object} req  The request object from connect/express
-     * @param {String} resource  The resource name
-     * @param {Object} params    The parameters identify the resource, and along with information
-     *                           carried in query and matrix parameters in typical REST API
-     * @param {Object} body      The JSON object that contains the resource data that is being updated
-     * @param {Object} [config={}] The config object.  It can contain "config" for per-request config data.
-     * @param {Fetcher~fetcherCallback} callback callback invoked when fetcher is complete.
-     * @static
-     */
-    update: function (req, resource, params, body, config, callback) {
-        callback(
-            null,
-            {
+
+    update: async function ({ resource, params }) {
+        const meta = this.meta || params.meta;
+        this.meta = null;
+
+        return {
+            data: {
                 operation: {
                     name: 'update',
                     success: true,
@@ -109,25 +78,16 @@ var MockService = {
                     params: params,
                 },
             },
-            this.meta || params.meta,
-        );
-        this.meta = null;
+            meta,
+        };
     },
-    /**
-     * delete operation (delete as in CRUD).
-     * @method delete
-     * @param {Object} req  The request object from connect/express
-     * @param {String} resource  The resource name
-     * @param {Object} params    The parameters identify the resource, and along with information
-     *                           carried in query and matrix parameters in typical REST API
-     * @param {Object} [config={}] The config object.  It can contain "config" for per-request config data.
-     * @param {Fetcher~fetcherCallback} callback callback invoked when fetcher is complete.
-     * @static
-     */
-    delete: function (req, resource, params, config, callback) {
-        callback(
-            null,
-            {
+
+    delete: async function ({ resource, params }) {
+        const meta = this.meta || params.meta;
+        this.meta = null;
+
+        return {
+            data: {
                 operation: {
                     name: 'delete',
                     success: true,
@@ -137,9 +97,8 @@ var MockService = {
                     params: params,
                 },
             },
-            this.meta || params.meta,
-        );
-        this.meta = null;
+            meta,
+        };
     },
 };
 


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

This PR enables fetchr to be used without any callback.

## Before
```js
function create(req, resource, params, body, config, callback) { 
    callback(err, data, meta)
}
```

## After
```js
async function create({ req, resource, params, body, config }) {
    return { data, meta }
 }
```

It's still possible to use the old signature since we detect the new one based on the number or arguments defined in the handler.

This change also make it simple to create handlers that do not require any argument:

## Before
```js
function create(req, resource, params, body, config, callback) {
    callback({ ok: true });
}
```

## After
```js
async function create() {
    return { data: { ok: true } };
}
```