### PR TITLE
fix: prevent fetchr to throw a 500 whenever a resource does not implement an operation

### DIFF
--- a/libs/fetcher.js
+++ b/libs/fetcher.js
@@ -252,8 +252,10 @@ class Request {
 
         if (!handler) {
             const err = new FetchrError(
-                `operation: ${this.operation} is undefined on service: ${this.resource}`,
+                `Operation "${this.operation}" is not allowed for resource "${sanitizeResourceName(this.resource)}"`,
             );
+            err.statusCode = 405;
+
             return { err };
         }
 

--- a/tests/functional/app.js
+++ b/tests/functional/app.js
@@ -19,7 +19,9 @@ app.use(express.json());
 
 app.use('/static', express.static(path.join(__dirname, 'static')));
 
-app.use('/api', Fetchr.middleware());
+app.use('/api', Fetchr.middleware(), (err, req, res, next) => {
+    res.status(err.statusCode || 500).json({ message: err.message });
+});
 
 app.get('/', (req, res) => {
     res.send(`

--- a/tests/functional/fetchr.test.js
+++ b/tests/functional/fetchr.test.js
@@ -595,6 +595,34 @@ describe('client/server integration', () => {
                 });
             });
         });
+
+        describe('client errors', () => {
+            it('handles unknown resources', async () => {
+                const response = await page.evaluate(() => {
+                    const fetcher = new Fetchr();
+                    return fetcher
+                        .create('unknown-resource')
+                        .catch((err) => err);
+                });
+
+                expect(response.statusCode).to.equal(400);
+                expect(response.message).to.equal(
+                    'Resource "unknown*resource" is not registered',
+                );
+            });
+
+            it('handles not implemented operations', async () => {
+                const response = await page.evaluate(() => {
+                    const fetcher = new Fetchr();
+                    return fetcher.delete('error').catch((err) => err);
+                });
+
+                expect(response.statusCode).to.equal(405);
+                expect(JSON.parse(response.message).output.message).to.equal(
+                    'Operation "delete" is not allowed for resource "error"',
+                );
+            });
+        });
     });
 
     describe('headers', () => {

--- a/tests/unit/libs/fetcher.client.js
+++ b/tests/unit/libs/fetcher.client.js
@@ -121,10 +121,20 @@ describe('Client Fetcher', function () {
                 }
             };
         });
+
         beforeEach(function () {
             stats = null;
         });
-        testCrud(params, body, config, callbackWithStats, resolve, reject);
+
+        testCrud({
+            params,
+            body,
+            config,
+            callback: callbackWithStats,
+            reject,
+            resolve,
+        });
+
         after(function () {
             validateRequest = null;
         });
@@ -147,15 +157,17 @@ describe('Client Fetcher', function () {
                 corsPath: corsPath,
             });
         });
+
         testCrud({
-            params: params,
-            body: body,
+            params,
+            body,
             config: { cors: true },
+            callback,
+            reject,
+            resolve,
             disableNoConfigTests: true,
-            callback: callback,
-            resolve: resolve,
-            reject: reject,
         });
+
         after(function () {
             validateRequest = null;
         });
@@ -222,7 +234,16 @@ describe('Client Fetcher', function () {
                     xhrTimeout: 4000,
                 });
             });
-            testCrud(params, body, config, callback, resolve, reject);
+
+            testCrud({
+                params,
+                body,
+                config,
+                callback,
+                resolve,
+                reject,
+            });
+
             after(function () {
                 mockery.deregisterMock('./util/httpRequest');
                 mockery.disable();
@@ -245,17 +266,17 @@ describe('Client Fetcher', function () {
                     xhrTimeout: 4000,
                 });
             });
+
             testCrud({
-                params: params,
-                body: body,
-                config: {
-                    timeout: 5000,
-                },
-                disableNoConfigTests: true,
+                params,
+                body,
+                config: { timeout: 5000 },
                 callback: callback,
                 resolve: resolve,
                 reject: reject,
+                disableNoConfigTests: true,
             });
+
             after(function () {
                 mockery.deregisterMock('./util/httpRequest');
                 mockery.disable();
@@ -277,7 +298,16 @@ describe('Client Fetcher', function () {
                     context: context,
                 });
             });
-            testCrud(params, body, config, callback, resolve, reject);
+
+            testCrud({
+                params,
+                body,
+                config,
+                callback,
+                resolve,
+                reject,
+            });
+
             after(function () {
                 mockery.deregisterMock('./util/httpRequest');
                 mockery.disable();
@@ -325,7 +355,14 @@ describe('Client Fetcher', function () {
                 });
             });
 
-            testCrud(params, body, config, callback, resolve, reject);
+            testCrud({
+                params,
+                body,
+                config,
+                callback,
+                resolve,
+                reject,
+            });
         });
 
         describe('Property Name', function () {
@@ -338,7 +375,14 @@ describe('Client Fetcher', function () {
                 });
             });
 
-            testCrud(params, body, config, callback, resolve, reject);
+            testCrud({
+                params,
+                body,
+                config,
+                callback,
+                resolve,
+                reject,
+            });
         });
 
         describe('Property Names', function () {
@@ -351,7 +395,14 @@ describe('Client Fetcher', function () {
                 });
             });
 
-            testCrud(params, body, config, callback, resolve, reject);
+            testCrud({
+                params,
+                body,
+                config,
+                callback,
+                resolve,
+                reject,
+            });
         });
     });
 
@@ -396,7 +447,16 @@ describe('Client Fetcher', function () {
                     },
                 });
             });
-            testCrud(params, body, config, callback, resolve, reject);
+
+            testCrud({
+                params,
+                body,
+                config,
+                callback,
+                resolve,
+                reject,
+            });
+
             after(function () {
                 mockery.deregisterMock('./util/httpRequest');
                 mockery.disable();
@@ -418,20 +478,17 @@ describe('Client Fetcher', function () {
                     context: context,
                 });
             });
-            var customConfig = {
-                headers: {
-                    'X-APP-VERSION': VERSION,
-                },
-            };
+
             testCrud({
+                params,
+                body,
+                config: { headers: { 'X-APP-VERSION': VERSION } },
+                callback,
+                resolve,
+                reject,
                 disableNoConfigTests: true,
-                params: params,
-                body: body,
-                config: customConfig,
-                callback: callback,
-                resolve: resolve,
-                reject: reject,
             });
+
             after(function () {
                 mockery.deregisterMock('./util/httpRequest');
                 mockery.disable();
@@ -679,7 +736,14 @@ describe('Client Fetcher', function () {
                 });
             });
 
-            testCrud(params, body, config, callback, resolve, reject);
+            testCrud({
+                params,
+                body,
+                config,
+                callback,
+                resolve,
+                reject,
+            });
 
             after(function () {
                 mockery.deregisterMock('./util/httpRequest');
@@ -705,23 +769,24 @@ describe('Client Fetcher', function () {
                 Fetcher = require('../../../libs/fetcher.client');
                 this.fetcher = new Fetcher({});
             });
-            var customConfig = {
-                retry: {
-                    interval: 350,
-                    maxRetries: 2,
-                    statusCodes: [0, 502, 504],
-                },
-                unsafeAllowRetry: true,
-            };
+
             testCrud({
+                params,
+                body,
+                config: {
+                    retry: {
+                        interval: 350,
+                        maxRetries: 2,
+                        statusCodes: [0, 502, 504],
+                    },
+                    unsafeAllowRetry: true,
+                },
+                callback,
+                resolve,
+                reject,
                 disableNoConfigTests: true,
-                params: params,
-                body: body,
-                config: customConfig,
-                callback: callback,
-                resolve: resolve,
-                reject: reject,
             });
+
             after(function () {
                 mockery.deregisterMock('./util/httpRequest');
                 mockery.disable();

--- a/tests/unit/libs/fetcher.js
+++ b/tests/unit/libs/fetcher.js
@@ -1301,6 +1301,7 @@ describe('Server Fetcher', function () {
             callback: callbackWithStats,
             resolve,
             reject,
+            isServer: true,
         });
     });
 });

--- a/tests/unit/libs/fetcher.js
+++ b/tests/unit/libs/fetcher.js
@@ -1293,8 +1293,15 @@ describe('Server Fetcher', function () {
         beforeEach(function () {
             stats = null;
         });
-        // CRUD
-        testCrud(params, body, config, callbackWithStats, resolve, reject);
+
+        testCrud({
+            params,
+            body,
+            config,
+            callback: callbackWithStats,
+            resolve,
+            reject,
+        });
     });
 });
 

--- a/tests/util/testCrud.js
+++ b/tests/util/testCrud.js
@@ -5,26 +5,15 @@ const invalidResource = 'invalid_resource';
 const mockErrorService = require('../mock/MockErrorService');
 const mockNoopService = require('../mock/MockNoopService');
 
-module.exports = function testCrud(
-    params,
-    body,
-    config,
-    callback,
-    resolve,
-    reject,
-) {
-    let options = {};
-
-    if (arguments.length === 1) {
-        options = params;
-        params = options.params || defaultOptions.params;
-        body = options.body || defaultOptions.body;
-        config = options.config || defaultOptions.config;
-        callback = options.callback || defaultOptions.callback;
-        resolve = options.resolve || defaultOptions.resolve;
-        reject = options.reject || defaultOptions.reject;
-    }
-
+module.exports = function testCrud({
+    params = defaultOptions.params,
+    body = defaultOptions.body,
+    config = defaultOptions.config,
+    callback = defaultOptions.callback,
+    resolve = defaultOptions.resolve,
+    reject = defaultOptions.reject,
+    disableNoConfigTests = false,
+}) {
     describe('CRUD Interface', function () {
         describe('should work superagent style', function () {
             describe('with callbacks', function () {
@@ -270,7 +259,7 @@ module.exports = function testCrud(
                 );
             });
 
-            if (!options.disableNoConfigTests) {
+            if (!disableNoConfigTests) {
                 // without config
                 // we have a feature flag to disable these tests because
                 // it doesn't make sense to test a feature like CORS without being able to pass in a config

--- a/tests/util/testCrud.js
+++ b/tests/util/testCrud.js
@@ -13,6 +13,7 @@ module.exports = function testCrud({
     resolve = defaultOptions.resolve,
     reject = defaultOptions.reject,
     disableNoConfigTests = false,
+    isServer = false,
 }) {
     describe('CRUD Interface', function () {
         describe('should work superagent style', function () {
@@ -408,16 +409,23 @@ module.exports = function testCrud({
         });
     });
 
-    describe('should reject no operation service', function () {
+    describe('should reject when resource does not implement operation', function () {
+        function getErrorMessage(err) {
+            return isServer
+                ? err.message
+                : JSON.parse(err.message).output.message;
+        }
+
         it('with callback', function (done) {
             const fetcher = this.fetcher;
             fetcher
                 .read(mockNoopService.resource)
                 .clientConfig(config)
                 .end(function (err) {
+                    const message = getErrorMessage(err);
                     expect(err.name).to.equal('FetchrError');
-                    expect(err.message).to.contain(
-                        'operation: read is undefined on service: mock_noop_service',
+                    expect(message).to.equal(
+                        'Operation "read" is not allowed for resource "mock_noop_service"',
                     );
                     done();
                 });
@@ -429,9 +437,10 @@ module.exports = function testCrud({
                 .read(mockNoopService.resource)
                 .clientConfig(config)
                 .catch(function (err) {
+                    const message = getErrorMessage(err);
                     expect(err.name).to.equal('FetchrError');
-                    expect(err.message).to.contain(
-                        'operation: read is undefined on service: mock_noop_service',
+                    expect(message).to.equal(
+                        'Operation "read" is not allowed for resource "mock_noop_service"',
                     );
                     done();
                 });

--- a/tests/util/testCrud.js
+++ b/tests/util/testCrud.js
@@ -1,9 +1,9 @@
-var expect = require('chai').expect;
-var defaultOptions = require('./defaultOptions');
-var resource = defaultOptions.resource;
-var invalidResource = 'invalid_resource';
-var mockErrorService = require('../mock/MockErrorService');
-var mockNoopService = require('../mock/MockNoopService');
+const expect = require('chai').expect;
+const defaultOptions = require('./defaultOptions');
+const resource = defaultOptions.resource;
+const invalidResource = 'invalid_resource';
+const mockErrorService = require('../mock/MockErrorService');
+const mockNoopService = require('../mock/MockNoopService');
 
 module.exports = function testCrud(
     params,
@@ -13,7 +13,8 @@ module.exports = function testCrud(
     resolve,
     reject,
 ) {
-    var options = {};
+    let options = {};
+
     if (arguments.length === 1) {
         options = params;
         params = options.params || defaultOptions.params;
@@ -23,39 +24,44 @@ module.exports = function testCrud(
         resolve = options.resolve || defaultOptions.resolve;
         reject = options.reject || defaultOptions.reject;
     }
+
     describe('CRUD Interface', function () {
         describe('should work superagent style', function () {
             describe('with callbacks', function () {
                 it('should handle CREATE', function (done) {
-                    var operation = 'create';
+                    const operation = 'create';
                     this.fetcher[operation](resource)
                         .params(params)
                         .body(body)
                         .clientConfig(config)
                         .end(callback(operation, done));
                 });
+
                 it('should handle READ', function (done) {
-                    var operation = 'read';
+                    const operation = 'read';
                     this.fetcher[operation](resource)
                         .params(params)
                         .clientConfig(config)
                         .end(callback(operation, done));
                 });
+
                 it('should handle UPDATE', function (done) {
-                    var operation = 'update';
+                    const operation = 'update';
                     this.fetcher[operation](resource)
                         .params(params)
                         .body(body)
                         .clientConfig(config)
                         .end(callback(operation, done));
                 });
+
                 it('should handle DELETE', function (done) {
-                    var operation = 'delete';
+                    const operation = 'delete';
                     this.fetcher[operation](resource)
                         .params(params)
                         .clientConfig(config)
                         .end(callback(operation, done));
                 });
+
                 it('should throw if no resource is given', function () {
                     expect(this.fetcher.read.bind(this.fetcher)).to.throw(
                         'Resource is required for a fetcher request',
@@ -64,90 +70,100 @@ module.exports = function testCrud(
             });
 
             describe('with Promises', function () {
-                it('should handle CREATE', function (done) {
-                    var operation = 'create';
-                    this.fetcher[operation](resource)
-                        .params(params)
-                        .body(body)
-                        .clientConfig(config)
-                        .then(
-                            resolve(operation, done),
-                            reject(operation, done),
-                        );
-                });
-                it('should handle READ', function (done) {
-                    var operation = 'read';
-                    this.fetcher[operation](resource)
-                        .params(params)
-                        .clientConfig(config)
-                        .then(
-                            resolve(operation, done),
-                            reject(operation, done),
-                        );
-                });
-                it('should handle UPDATE', function (done) {
-                    var operation = 'update';
-                    this.fetcher[operation](resource)
-                        .params(params)
-                        .body(body)
-                        .clientConfig(config)
-                        .then(
-                            resolve(operation, done),
-                            reject(operation, done),
-                        );
-                });
-                it('should handle DELETE', function (done) {
-                    var operation = 'delete';
-                    this.fetcher[operation](resource)
-                        .params(params)
-                        .clientConfig(config)
-                        .then(
-                            resolve(operation, done),
-                            reject(operation, done),
-                        );
-                });
-                var denySuccess = function (done) {
+                function denySuccess(done) {
                     return function () {
                         done(new Error('This operation should have failed'));
                     };
-                };
-                var allowFailure = function (done) {
+                }
+
+                function allowFailure(done) {
                     return function (err) {
                         expect(err.name).to.equal('FetchrError');
                         expect(err.message).to.exist;
                         done();
                     };
-                };
+                }
+
+                it('should handle CREATE', function (done) {
+                    const operation = 'create';
+                    this.fetcher[operation](resource)
+                        .params(params)
+                        .body(body)
+                        .clientConfig(config)
+                        .then(
+                            resolve(operation, done),
+                            reject(operation, done),
+                        );
+                });
+
+                it('should handle READ', function (done) {
+                    const operation = 'read';
+                    this.fetcher[operation](resource)
+                        .params(params)
+                        .clientConfig(config)
+                        .then(
+                            resolve(operation, done),
+                            reject(operation, done),
+                        );
+                });
+
+                it('should handle UPDATE', function (done) {
+                    const operation = 'update';
+                    this.fetcher[operation](resource)
+                        .params(params)
+                        .body(body)
+                        .clientConfig(config)
+                        .then(
+                            resolve(operation, done),
+                            reject(operation, done),
+                        );
+                });
+
+                it('should handle DELETE', function (done) {
+                    const operation = 'delete';
+                    this.fetcher[operation](resource)
+                        .params(params)
+                        .clientConfig(config)
+                        .then(
+                            resolve(operation, done),
+                            reject(operation, done),
+                        );
+                });
+
                 it('should reject a CREATE promise on invalid resource', function (done) {
-                    var operation = 'create';
+                    const operation = 'create';
                     this.fetcher[operation](invalidResource)
                         .params(params)
                         .body(body)
                         .clientConfig(config)
                         .then(denySuccess(done), allowFailure(done));
                 });
+
                 it('should reject a READ promise on invalid resource', function (done) {
-                    var operation = 'read';
+                    const operation = 'read';
                     this.fetcher[operation](invalidResource)
                         .params(params)
                         .clientConfig(config)
                         .then(denySuccess(done), allowFailure(done));
                 });
+
                 it('should reject a UPDATE promise on invalid resource', function (done) {
-                    var operation = 'update';
+                    const operation = 'update';
                     this.fetcher[operation](invalidResource)
                         .params(params)
                         .body(body)
                         .clientConfig(config)
                         .then(denySuccess(done), allowFailure(done));
                 });
+
                 it('should reject a DELETE promise on invalid resource', function (done) {
-                    var operation = 'delete';
+                    const operation = 'delete';
                     this.fetcher[operation](invalidResource)
                         .params(params)
                         .clientConfig(config)
                         .then(denySuccess(done), allowFailure(done));
                 });
+
                 it('should throw if no resource is given', function () {
                     expect(this.fetcher.read.bind(this.fetcher)).to.throw(
                         'Resource is required for a fetcher request',
@@ -155,47 +171,9 @@ module.exports = function testCrud(
                 });
             });
         });
+
         describe('should be backwards compatible', function () {
-            // with config
-            it('should handle CREATE', function (done) {
-                var operation = 'create';
-                this.fetcher[operation](
-                    resource,
-                    params,
-                    body,
-                    config,
-                    callback(operation, done),
-                );
-            });
-            it('should handle READ', function (done) {
-                var operation = 'read';
-                this.fetcher[operation](
-                    resource,
-                    params,
-                    config,
-                    callback(operation, done),
-                );
-            });
-            it('should handle UPDATE', function (done) {
-                var operation = 'update';
-                this.fetcher[operation](
-                    resource,
-                    params,
-                    body,
-                    config,
-                    callback(operation, done),
-                );
-            });
-            it('should handle DELETE', function (done) {
-                var operation = 'delete';
-                this.fetcher[operation](
-                    resource,
-                    params,
-                    config,
-                    callback(operation, done),
-                );
-            });
-            var denySuccess = function (done) {
+            function denySuccess(done) {
                 return function (err) {
                     if (!err) {
                         done(new Error('This operation should have failed'));
@@ -205,9 +183,53 @@ module.exports = function testCrud(
                         done();
                     }
                 };
-            };
+            }
+
+            // with config
+            it('should handle CREATE', function (done) {
+                const operation = 'create';
+                this.fetcher[operation](
+                    resource,
+                    params,
+                    body,
+                    config,
+                    callback(operation, done),
+                );
+            });
+
+            it('should handle READ', function (done) {
+                const operation = 'read';
+                this.fetcher[operation](
+                    resource,
+                    params,
+                    config,
+                    callback(operation, done),
+                );
+            });
+
+            it('should handle UPDATE', function (done) {
+                const operation = 'update';
+                this.fetcher[operation](
+                    resource,
+                    params,
+                    body,
+                    config,
+                    callback(operation, done),
+                );
+            });
+
+            it('should handle DELETE', function (done) {
+                const operation = 'delete';
+                this.fetcher[operation](
+                    resource,
+                    params,
+                    config,
+                    callback(operation, done),
+                );
+            });
+
             it('should throw catchable error on CREATE with invalid resource', function (done) {
-                var operation = 'create';
+                const operation = 'create';
                 this.fetcher[operation](
                     invalidResource,
                     params,
@@ -216,8 +238,9 @@ module.exports = function testCrud(
                     denySuccess(done),
                 );
             });
+
             it('should throw catchable error on READ with invalid resource', function (done) {
-                var operation = 'read';
+                const operation = 'read';
                 this.fetcher[operation](
                     invalidResource,
                     params,
@@ -225,8 +248,9 @@ module.exports = function testCrud(
                     denySuccess(done),
                 );
             });
+
             it('should throw catchable error on UPDATE with invalid resource', function (done) {
-                var operation = 'update';
+                const operation = 'update';
                 this.fetcher[operation](
                     invalidResource,
                     params,
@@ -235,8 +259,9 @@ module.exports = function testCrud(
                     denySuccess(done),
                 );
             });
+
             it('should throw catchable error on DELETE with invalid resource', function (done) {
-                var operation = 'delete';
+                const operation = 'delete';
                 this.fetcher[operation](
                     invalidResource,
                     params,
@@ -244,12 +269,13 @@ module.exports = function testCrud(
                     denySuccess(done),
                 );
             });
+
             if (!options.disableNoConfigTests) {
                 // without config
                 // we have a feature flag to disable these tests because
                 // it doesn't make sense to test a feature like CORS without being able to pass in a config
                 it('should handle CREATE w/ no config', function (done) {
-                    var operation = 'create';
+                    const operation = 'create';
                     this.fetcher[operation](
                         resource,
                         params,
@@ -257,16 +283,18 @@ module.exports = function testCrud(
                         callback(operation, done),
                     );
                 });
+
                 it('should handle READ w/ no config', function (done) {
-                    var operation = 'read';
+                    const operation = 'read';
                     this.fetcher[operation](
                         resource,
                         params,
                         callback(operation, done),
                     );
                 });
+
                 it('should handle UPDATE w/ no config', function (done) {
-                    var operation = 'update';
+                    const operation = 'update';
                     this.fetcher[operation](
                         resource,
                         params,
@@ -274,8 +302,9 @@ module.exports = function testCrud(
                         callback(operation, done),
                     );
                 });
+
                 it('should handle DELETE w/ no config', function (done) {
-                    var operation = 'delete';
+                    const operation = 'delete';
                     this.fetcher[operation](
                         resource,
                         params,
@@ -284,8 +313,9 @@ module.exports = function testCrud(
                 });
             }
         });
+
         it('should keep track of metadata in getServiceMeta', function (done) {
-            var fetcher = this.fetcher;
+            const fetcher = this.fetcher;
             fetcher._serviceMeta.length = 0; // reset serviceMeta to empty array
             fetcher
                 .read(resource)
@@ -315,7 +345,7 @@ module.exports = function testCrud(
                             expect(meta).to.include.keys('headers');
                             expect(meta.headers).to.include.keys('x-bar');
                             expect(meta.headers['x-bar']).to.equal('bar');
-                            var serviceMeta = fetcher.getServiceMeta();
+                            const serviceMeta = fetcher.getServiceMeta();
                             expect(serviceMeta).to.have.length(2);
                             expect(serviceMeta[0].headers).to.include.keys(
                                 'x-foo',
@@ -333,9 +363,10 @@ module.exports = function testCrud(
                         });
                 });
         });
+
         describe('should have serviceMeta data on error', function () {
             it('with callbacks', function (done) {
-                var fetcher = this.fetcher;
+                const fetcher = this.fetcher;
                 fetcher._serviceMeta.length = 0; // reset serviceMeta to empty array
                 fetcher
                     .read(mockErrorService.resource)
@@ -346,7 +377,7 @@ module.exports = function testCrud(
                     .clientConfig(config)
                     .end(function (err) {
                         if (err) {
-                            var serviceMeta = fetcher.getServiceMeta();
+                            const serviceMeta = fetcher.getServiceMeta();
                             expect(serviceMeta).to.have.length(1);
                             expect(serviceMeta[0]).to.include.keys('headers');
                             expect(serviceMeta[0].headers).to.include.keys(
@@ -359,8 +390,9 @@ module.exports = function testCrud(
                         }
                     });
             });
+
             it('with Promises', function (done) {
-                var fetcher = this.fetcher;
+                const fetcher = this.fetcher;
                 fetcher._serviceMeta.length = 0; // reset serviceMeta to empty array
                 fetcher
                     .read(mockErrorService.resource)
@@ -371,7 +403,7 @@ module.exports = function testCrud(
                     .clientConfig(config)
                     .catch(function (err) {
                         if (err) {
-                            var serviceMeta = fetcher.getServiceMeta();
+                            const serviceMeta = fetcher.getServiceMeta();
                             expect(serviceMeta).to.have.length(1);
                             expect(serviceMeta[0]).to.include.keys('headers');
                             expect(serviceMeta[0].headers).to.include.keys(
@@ -386,9 +418,10 @@ module.exports = function testCrud(
             });
         });
     });
+
     describe('should reject no operation service', function () {
         it('with callback', function (done) {
-            var fetcher = this.fetcher;
+            const fetcher = this.fetcher;
             fetcher
                 .read(mockNoopService.resource)
                 .clientConfig(config)
@@ -400,8 +433,9 @@ module.exports = function testCrud(
                     done();
                 });
         });
+
         it('with Promise', function (done) {
-            var fetcher = this.fetcher;
+            const fetcher = this.fetcher;
             fetcher
                 .read(mockNoopService.resource)
                 .clientConfig(config)


### PR DESCRIPTION
We are getting some alerts on our systems whenever some bot our security scanner try to hit a fetchr resource using an operation that is not registered. 

The most common case is when a resource only implements the `create` method (which requires a POST request). The bots try to hit this resource with a GET request, which makes fetchr middleware to think that this is a a `read` operation. Since the resource does not implement it, fetchr throws an error. Before this change this error wouldn't include a status code which would default to a 500. But since this is a client error and we are talking about not implemented methods, I thought that a 405 would be more appropriate.

I really thought that this would be a trivial change (I actually tried it a long time ago, but I gave up and just decided to handle it in our services directly). The main issue is that `testCrud` is used for both server and client tests. Even though the interface is the same, the errors are different: in the client, fetchr is mainly handling an http error and `FetchrError.message` includes the whole response body. But in the server (since there is no response yet), `FetchrError.message` is just the error message itself. This is why you also see some refactoring here for `testCrud` so we can do this differentiation in the test.

The other issue that I found while solving this one is that we don't have a consistent way of throwing errors in the server. Sometimes it's handled in the middleware before triggering a fetchr request. In this case, we call express `next` function with a HttpError generated by fumble. But sometimes, we let the request go through fetchr and, if any error happens, we throw an `FetchrError` and handle the response within fetchr middleware. This behavior is quite visible now on the functional test where in the first case we get as response `{ "message": "error" }`  and in the second case a `{ "output": { "message": "error" }, "meta": {} }`.
This is not an issue to fetchr client since it can handle all kind of errors consistently. But it is an issue if one wants to consistently monitor/track errors on the server: the first case of errors must be handled in a custom express error middleware (as I added in the functional tests) and the second case must be handled within a fetchr `statsCollector` function.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
